### PR TITLE
feat: upgrade bpmn-to-code to v2.0.3

### DIFF
--- a/examples/after-transaction/build.gradle.kts
+++ b/examples/after-transaction/build.gradle.kts
@@ -40,7 +40,6 @@ tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
     packagePath = "io.miragon.example.adapter.process"
     outputLanguage = OutputLanguage.KOTLIN
     processEngine = ProcessEngine.ZEEBE
-    useVersioning = false
 }
 
 java {

--- a/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/in/zeebe/AbortRegistrationWorker.kt
+++ b/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/in/zeebe/AbortRegistrationWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.AbortSubscriptionUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -14,7 +14,7 @@ class AbortRegistrationWorker(private val useCase: AbortSubscriptionUseCase) {
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_ABORT_REGISTRATION)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_ABORT_REGISTRATION)
     fun abortRegistration(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job to abort registration: $subscriptionId" }
         useCase.abort(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendConfirmationMailWorker.kt
+++ b/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendConfirmationMailWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.SendConfirmationMailUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -14,7 +14,7 @@ class SendConfirmationMailWorker(private val useCase: SendConfirmationMailUseCas
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_CONFIRMATION_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_CONFIRMATION_MAIL)
     fun sendConfirmationMail(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job to send confirmation mail: $subscriptionId" }
         useCase.sendConfirmationMail(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
+++ b/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.SendWelcomeMailUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -14,7 +14,7 @@ class SendWelcomeMailWorker(private val useCase: SendWelcomeMailUseCase) {
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_WELCOME_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_WELCOME_MAIL)
     fun sendConfirmationMail(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job to send welcome mail: $subscriptionId" }
         useCase.sendWelcomeMail(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapter.kt
+++ b/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapter.kt
@@ -2,6 +2,7 @@ package io.miragon.example.adapter.out.zeebe
 
 import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_FORM_SUBMITTED
 import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_SUBSCRIPTION_CONFIRMED
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Variables
 import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
 import io.miragon.example.domain.SubscriptionId
 import org.springframework.stereotype.Component
@@ -12,9 +13,9 @@ class NewsletterSubscriptionProcessAdapter(
 ) : NewsletterSubscriptionProcess {
 
     override fun submitForm(id: SubscriptionId) {
-        val variables = mapOf("subscriptionId" to id.value.toString())
+        val variables = mapOf(Variables.StartEventSubmitRegistrationForm.SUBSCRIPTION_ID.value to id.value.toString())
         engineApi.startProcessViaMessage(
-            messageName = MESSAGE_FORM_SUBMITTED,
+            messageName = MESSAGE_FORM_SUBMITTED.value,
             correlationId = id.value.toString(),
             variables = variables
         )
@@ -22,7 +23,7 @@ class NewsletterSubscriptionProcessAdapter(
 
     override fun confirmSubscription(id: SubscriptionId) {
         engineApi.sendMessage(
-            messageName = MESSAGE_SUBSCRIPTION_CONFIRMED,
+            messageName = MESSAGE_SUBSCRIPTION_CONFIRMED.value,
             correlationId = id.value.toString(),
         )
     }

--- a/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
+++ b/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
@@ -3,48 +3,72 @@
 
 package io.miragon.example.adapter.process
 
+import io.github.emaarco.bpmn.runtime.BpmnEngine
+import io.github.emaarco.bpmn.runtime.BpmnFlow
+import io.github.emaarco.bpmn.runtime.BpmnRelations
+import io.github.emaarco.bpmn.runtime.BpmnTimer
+import io.github.emaarco.bpmn.runtime.ElementId
+import io.github.emaarco.bpmn.runtime.MessageName
+import io.github.emaarco.bpmn.runtime.ProcessId
+import io.github.emaarco.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 
 object NewsletterSubscriptionProcessApi {
-  const val PROCESS_ID: String = "newsletter-subscription"
+  val PROCESS_ID: ProcessId = ProcessId("newsletter-subscription")
 
-  const val PROCESS_ENGINE: String = "ZEEBE"
+  val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
+  /**
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests or when searching for tasks.
+   * Worker runtime code rarely needs these.
+   */
   object Elements {
-    const val ACTIVITY_ABORT_REGISTRATION: String = "Activity_AbortRegistration"
+    val ACTIVITY_ABORT_REGISTRATION: ElementId = ElementId("Activity_AbortRegistration")
 
-    const val ACTIVITY_CONFIRM_REGISTRATION: String = "Activity_ConfirmRegistration"
+    val ACTIVITY_CONFIRM_REGISTRATION: ElementId = ElementId("Activity_ConfirmRegistration")
 
-    const val ACTIVITY_SEND_CONFIRMATION_MAIL: String = "Activity_SendConfirmationMail"
+    val ACTIVITY_SEND_CONFIRMATION_MAIL: ElementId =
+        ElementId("Activity_SendConfirmationMail")
 
-    const val ACTIVITY_SEND_WELCOME_MAIL: String = "Activity_SendWelcomeMail"
+    val ACTIVITY_SEND_WELCOME_MAIL: ElementId = ElementId("Activity_SendWelcomeMail")
 
-    const val END_EVENT_REGISTRATION_ABORTED: String = "EndEvent_RegistrationAborted"
+    val END_EVENT_REGISTRATION_ABORTED: ElementId = ElementId("EndEvent_RegistrationAborted")
 
-    const val END_EVENT_REGISTRATION_COMPLETED: String = "EndEvent_RegistrationCompleted"
+    val END_EVENT_REGISTRATION_COMPLETED: ElementId =
+        ElementId("EndEvent_RegistrationCompleted")
 
-    const val END_EVENT_SUBSCRIPTION_CONFIRMED: String = "EndEvent_SubscriptionConfirmed"
+    val END_EVENT_SUBSCRIPTION_CONFIRMED: ElementId =
+        ElementId("EndEvent_SubscriptionConfirmed")
 
-    const val START_EVENT_REQUEST_RECEIVED: String = "StartEvent_RequestReceived"
+    val START_EVENT_REQUEST_RECEIVED: ElementId = ElementId("StartEvent_RequestReceived")
 
-    const val START_EVENT_SUBMIT_REGISTRATION_FORM: String =
-        "StartEvent_SubmitRegistrationForm"
+    val START_EVENT_SUBMIT_REGISTRATION_FORM: ElementId =
+        ElementId("StartEvent_SubmitRegistrationForm")
 
-    const val SUB_PROCESS_CONFIRMATION: String = "SubProcess_Confirmation"
+    val SUB_PROCESS_CONFIRMATION: ElementId = ElementId("SubProcess_Confirmation")
 
-    const val TIMER_AFTER_3_DAYS: String = "Timer_After3Days"
+    val TIMER_AFTER_3_DAYS: ElementId = ElementId("Timer_After3Days")
 
-    const val TIMER_EVERY_DAY: String = "Timer_EveryDay"
+    val TIMER_EVERY_DAY: ElementId = ElementId("Timer_EveryDay")
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   object Messages {
-    const val MESSAGE_FORM_SUBMITTED: String = "Message_FormSubmitted"
+    val MESSAGE_FORM_SUBMITTED: MessageName = MessageName("Message_FormSubmitted")
 
-    const val MESSAGE_SUBSCRIPTION_CONFIRMED: String = "Message_SubscriptionConfirmed"
+    val MESSAGE_SUBSCRIPTION_CONFIRMED: MessageName =
+        MessageName("Message_SubscriptionConfirmed")
   }
 
-  object TaskTypes {
+  /**
+   * Job worker task types used in `@JobWorker(type = ServiceTasks.X)` annotations.
+   * Kept as `const val String` because annotation arguments must be compile-time constants.
+   */
+  object ServiceTasks {
     const val NEWSLETTER_ABORT_REGISTRATION: String = "newsletter.abortRegistration"
 
     const val NEWSLETTER_REGISTRATION_COMPLETED: String = "newsletter.registrationCompleted"
@@ -58,14 +82,199 @@ object NewsletterSubscriptionProcessApi {
     val TIMER_AFTER_3_DAYS: BpmnTimer = BpmnTimer("Duration", "PT2M30S")
 
     val TIMER_EVERY_DAY: BpmnTimer = BpmnTimer("Duration", "PT1M")
-
-    data class BpmnTimer(
-      val type: String,
-      val timerValue: String,
-    )
   }
 
+  /**
+   * Process variables grouped by the BPMN element that declares them.
+   * Direction is encoded in each variable's wrapper type: `VariableName.Input`, `VariableName.Output`, or `VariableName.InOut` when the variable is both read and written by the same element.
+   * Consumer APIs that take a specific subtype (e.g. `fun setOutput(v: VariableName.Output)`) get compile-time direction enforcement.
+   */
   object Variables {
-    const val SUBSCRIPTION_ID: String = "subscriptionId"
+    object EndEventRegistrationCompleted {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+
+    object StartEventRequestReceived {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+
+    object StartEventSubmitRegistrationForm {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+  }
+
+  /**
+   * Sequence flows between BPMN elements.
+   * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+   * Worker code typically does not need these.
+   */
+  object Flows {
+    val FLOW_05_I_3_X_1_Y: BpmnFlow = BpmnFlow(
+          id = "Flow_05i3x1y",
+          sourceRef = "StartEvent_RequestReceived",
+          targetRef = "Activity_SendConfirmationMail",
+        )
+
+    val FLOW_09_CUVZP: BpmnFlow = BpmnFlow(
+          id = "Flow_09cuvzp",
+          sourceRef = "SubProcess_Confirmation",
+          targetRef = "Activity_SendWelcomeMail",
+        )
+
+    val FLOW_0_X_4_EWVB: BpmnFlow = BpmnFlow(
+          id = "Flow_0x4ewvb",
+          sourceRef = "Timer_EveryDay",
+          targetRef = "Activity_SendConfirmationMail",
+        )
+
+    val FLOW_1_BCKM_43: BpmnFlow = BpmnFlow(
+          id = "Flow_1bckm43",
+          sourceRef = "Activity_SendConfirmationMail",
+          targetRef = "Activity_ConfirmRegistration",
+        )
+
+    val FLOW_1_BSB_8_NO: BpmnFlow = BpmnFlow(
+          id = "Flow_1bsb8no",
+          sourceRef = "Activity_AbortRegistration",
+          targetRef = "EndEvent_RegistrationAborted",
+        )
+
+    val FLOW_1_CPWE_57: BpmnFlow = BpmnFlow(
+          id = "Flow_1cpwe57",
+          sourceRef = "Activity_ConfirmRegistration",
+          targetRef = "EndEvent_SubscriptionConfirmed",
+        )
+
+    val FLOW_1_CSFYYZ: BpmnFlow = BpmnFlow(
+          id = "Flow_1csfyyz",
+          sourceRef = "StartEvent_SubmitRegistrationForm",
+          targetRef = "SubProcess_Confirmation",
+        )
+
+    val FLOW_1_I_7_HJID: BpmnFlow = BpmnFlow(
+          id = "Flow_1i7hjid",
+          sourceRef = "Activity_SendWelcomeMail",
+          targetRef = "EndEvent_RegistrationCompleted",
+        )
+
+    val FLOW_1_L_1_LJ_4_M: BpmnFlow = BpmnFlow(
+          id = "Flow_1l1lj4m",
+          sourceRef = "Timer_After3Days",
+          targetRef = "Activity_AbortRegistration",
+        )
+  }
+
+  /**
+   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Intended for tooling and tests, not worker runtime code.
+   */
+  object Relations {
+    val ACTIVITY_ABORT_REGISTRATION: BpmnRelations = BpmnRelations(
+          name = "Abort registration",
+          previousElements = listOf("Timer_After3Days"),
+          followingElements = listOf("EndEvent_RegistrationAborted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val ACTIVITY_CONFIRM_REGISTRATION: BpmnRelations = BpmnRelations(
+          name = "Confirm subscription",
+          previousElements = listOf("Activity_SendConfirmationMail"),
+          followingElements = listOf("EndEvent_SubscriptionConfirmed"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = listOf("Timer_EveryDay"),
+        )
+
+    val ACTIVITY_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send confirmation mail",
+          previousElements = listOf("StartEvent_RequestReceived", "Timer_EveryDay"),
+          followingElements = listOf("Activity_ConfirmRegistration"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val ACTIVITY_SEND_WELCOME_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send Welcome-Mail",
+          previousElements = listOf("SubProcess_Confirmation"),
+          followingElements = listOf("EndEvent_RegistrationCompleted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_REGISTRATION_ABORTED: BpmnRelations = BpmnRelations(
+          name = "Registration aborted",
+          previousElements = listOf("Activity_AbortRegistration"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_REGISTRATION_COMPLETED: BpmnRelations = BpmnRelations(
+          name = "Registration completed",
+          previousElements = listOf("Activity_SendWelcomeMail"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_SUBSCRIPTION_CONFIRMED: BpmnRelations = BpmnRelations(
+          name = "Subscription confirmed",
+          previousElements = listOf("Activity_ConfirmRegistration"),
+          followingElements = emptyList(),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_REQUEST_RECEIVED: BpmnRelations = BpmnRelations(
+          name = "Subscription requested",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_SUBMIT_REGISTRATION_FORM: BpmnRelations = BpmnRelations(
+          name = "Submit newsletter form",
+          previousElements = emptyList(),
+          followingElements = listOf("SubProcess_Confirmation"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SUB_PROCESS_CONFIRMATION: BpmnRelations = BpmnRelations(
+          name = "Subscription Confirmation",
+          previousElements = listOf("StartEvent_SubmitRegistrationForm"),
+          followingElements = listOf("Activity_SendWelcomeMail"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = listOf("Timer_After3Days"),
+        )
+
+    val TIMER_AFTER_3_DAYS: BpmnRelations = BpmnRelations(
+          name = "After 3 days",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_AbortRegistration"),
+          parentId = null,
+          attachedToRef = "SubProcess_Confirmation",
+          attachedElements = emptyList(),
+        )
+
+    val TIMER_EVERY_DAY: BpmnRelations = BpmnRelations(
+          name = "Every day",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = "Activity_ConfirmRegistration",
+          attachedElements = emptyList(),
+        )
   }
 }

--- a/examples/base-scenario/build.gradle.kts
+++ b/examples/base-scenario/build.gradle.kts
@@ -40,7 +40,6 @@ tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
     packagePath = "io.miragon.example.adapter.process"
     outputLanguage = OutputLanguage.KOTLIN
     processEngine = ProcessEngine.ZEEBE
-    useVersioning = false
 }
 
 java {

--- a/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/in/zeebe/AbortRegistrationWorker.kt
+++ b/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/in/zeebe/AbortRegistrationWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.AbortSubscriptionUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -14,7 +14,7 @@ class AbortRegistrationWorker(private val useCase: AbortSubscriptionUseCase) {
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_ABORT_REGISTRATION)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_ABORT_REGISTRATION)
     fun abortRegistration(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job to abort registration: $subscriptionId" }
         useCase.abort(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/in/zeebe/RegistrationCompletedWorker.kt
+++ b/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/in/zeebe/RegistrationCompletedWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.IncrementSubscriptionCounterUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -29,7 +29,7 @@ class RegistrationCompletedWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_REGISTRATION_COMPLETED)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_REGISTRATION_COMPLETED)
     fun handleRegistrationCompleted(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job for registration completed: $subscriptionId" }
         useCase.incrementCounter(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendConfirmationMailWorker.kt
+++ b/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendConfirmationMailWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.SendConfirmationMailUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -14,7 +14,7 @@ class SendConfirmationMailWorker(private val useCase: SendConfirmationMailUseCas
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_CONFIRMATION_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_CONFIRMATION_MAIL)
     fun sendConfirmationMail(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job to send confirmation mail: $subscriptionId" }
         useCase.sendConfirmationMail(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
+++ b/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.SendWelcomeMailUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -14,7 +14,7 @@ class SendWelcomeMailWorker(private val useCase: SendWelcomeMailUseCase) {
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_WELCOME_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_WELCOME_MAIL)
     fun sendConfirmationMail(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job to send welcome mail: $subscriptionId" }
         useCase.sendWelcomeMail(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapter.kt
+++ b/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapter.kt
@@ -2,6 +2,7 @@ package io.miragon.example.adapter.out.zeebe
 
 import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_FORM_SUBMITTED
 import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_SUBSCRIPTION_CONFIRMED
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Variables
 import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.CamundaClient
@@ -23,10 +24,10 @@ class NewsletterSubscriptionProcessAdapter(
 
     override fun submitForm(id: SubscriptionId) {
         // PROBLEM: This call happens immediately, potentially before the DB commit!
-        val variables = mapOf("subscriptionId" to id.value.toString())
+        val variables = mapOf(Variables.StartEventSubmitRegistrationForm.SUBSCRIPTION_ID.value to id.value.toString())
         val allVariables = variables + mapOf("correlationId" to id.value.toString())
         camundaClient.newPublishMessageCommand()
-            .messageName(MESSAGE_FORM_SUBMITTED)
+            .messageName(MESSAGE_FORM_SUBMITTED.value)
             .withoutCorrelationKey()
             .variables(allVariables)
             .send()
@@ -36,7 +37,7 @@ class NewsletterSubscriptionProcessAdapter(
     override fun confirmSubscription(id: SubscriptionId) {
         // PROBLEM: This call happens immediately, potentially before the DB commit!
         camundaClient.newPublishMessageCommand()
-            .messageName(MESSAGE_SUBSCRIPTION_CONFIRMED)
+            .messageName(MESSAGE_SUBSCRIPTION_CONFIRMED.value)
             .correlationKey(id.value.toString())
             .timeToLive(Duration.of(10, ChronoUnit.SECONDS))
             .send()

--- a/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
+++ b/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
@@ -3,48 +3,72 @@
 
 package io.miragon.example.adapter.process
 
+import io.github.emaarco.bpmn.runtime.BpmnEngine
+import io.github.emaarco.bpmn.runtime.BpmnFlow
+import io.github.emaarco.bpmn.runtime.BpmnRelations
+import io.github.emaarco.bpmn.runtime.BpmnTimer
+import io.github.emaarco.bpmn.runtime.ElementId
+import io.github.emaarco.bpmn.runtime.MessageName
+import io.github.emaarco.bpmn.runtime.ProcessId
+import io.github.emaarco.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 
 object NewsletterSubscriptionProcessApi {
-  const val PROCESS_ID: String = "newsletter-subscription"
+  val PROCESS_ID: ProcessId = ProcessId("newsletter-subscription")
 
-  const val PROCESS_ENGINE: String = "ZEEBE"
+  val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
+  /**
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests or when searching for tasks.
+   * Worker runtime code rarely needs these.
+   */
   object Elements {
-    const val ACTIVITY_ABORT_REGISTRATION: String = "Activity_AbortRegistration"
+    val ACTIVITY_ABORT_REGISTRATION: ElementId = ElementId("Activity_AbortRegistration")
 
-    const val ACTIVITY_CONFIRM_REGISTRATION: String = "Activity_ConfirmRegistration"
+    val ACTIVITY_CONFIRM_REGISTRATION: ElementId = ElementId("Activity_ConfirmRegistration")
 
-    const val ACTIVITY_SEND_CONFIRMATION_MAIL: String = "Activity_SendConfirmationMail"
+    val ACTIVITY_SEND_CONFIRMATION_MAIL: ElementId =
+        ElementId("Activity_SendConfirmationMail")
 
-    const val ACTIVITY_SEND_WELCOME_MAIL: String = "Activity_SendWelcomeMail"
+    val ACTIVITY_SEND_WELCOME_MAIL: ElementId = ElementId("Activity_SendWelcomeMail")
 
-    const val END_EVENT_REGISTRATION_ABORTED: String = "EndEvent_RegistrationAborted"
+    val END_EVENT_REGISTRATION_ABORTED: ElementId = ElementId("EndEvent_RegistrationAborted")
 
-    const val END_EVENT_REGISTRATION_COMPLETED: String = "EndEvent_RegistrationCompleted"
+    val END_EVENT_REGISTRATION_COMPLETED: ElementId =
+        ElementId("EndEvent_RegistrationCompleted")
 
-    const val END_EVENT_SUBSCRIPTION_CONFIRMED: String = "EndEvent_SubscriptionConfirmed"
+    val END_EVENT_SUBSCRIPTION_CONFIRMED: ElementId =
+        ElementId("EndEvent_SubscriptionConfirmed")
 
-    const val START_EVENT_REQUEST_RECEIVED: String = "StartEvent_RequestReceived"
+    val START_EVENT_REQUEST_RECEIVED: ElementId = ElementId("StartEvent_RequestReceived")
 
-    const val START_EVENT_SUBMIT_REGISTRATION_FORM: String =
-        "StartEvent_SubmitRegistrationForm"
+    val START_EVENT_SUBMIT_REGISTRATION_FORM: ElementId =
+        ElementId("StartEvent_SubmitRegistrationForm")
 
-    const val SUB_PROCESS_CONFIRMATION: String = "SubProcess_Confirmation"
+    val SUB_PROCESS_CONFIRMATION: ElementId = ElementId("SubProcess_Confirmation")
 
-    const val TIMER_AFTER_3_DAYS: String = "Timer_After3Days"
+    val TIMER_AFTER_3_DAYS: ElementId = ElementId("Timer_After3Days")
 
-    const val TIMER_EVERY_DAY: String = "Timer_EveryDay"
+    val TIMER_EVERY_DAY: ElementId = ElementId("Timer_EveryDay")
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   object Messages {
-    const val MESSAGE_FORM_SUBMITTED: String = "Message_FormSubmitted"
+    val MESSAGE_FORM_SUBMITTED: MessageName = MessageName("Message_FormSubmitted")
 
-    const val MESSAGE_SUBSCRIPTION_CONFIRMED: String = "Message_SubscriptionConfirmed"
+    val MESSAGE_SUBSCRIPTION_CONFIRMED: MessageName =
+        MessageName("Message_SubscriptionConfirmed")
   }
 
-  object TaskTypes {
+  /**
+   * Job worker task types used in `@JobWorker(type = ServiceTasks.X)` annotations.
+   * Kept as `const val String` because annotation arguments must be compile-time constants.
+   */
+  object ServiceTasks {
     const val NEWSLETTER_ABORT_REGISTRATION: String = "newsletter.abortRegistration"
 
     const val NEWSLETTER_REGISTRATION_COMPLETED: String = "newsletter.registrationCompleted"
@@ -58,14 +82,199 @@ object NewsletterSubscriptionProcessApi {
     val TIMER_AFTER_3_DAYS: BpmnTimer = BpmnTimer("Duration", "PT2M30S")
 
     val TIMER_EVERY_DAY: BpmnTimer = BpmnTimer("Duration", "PT1M")
-
-    data class BpmnTimer(
-      val type: String,
-      val timerValue: String,
-    )
   }
 
+  /**
+   * Process variables grouped by the BPMN element that declares them.
+   * Direction is encoded in each variable's wrapper type: `VariableName.Input`, `VariableName.Output`, or `VariableName.InOut` when the variable is both read and written by the same element.
+   * Consumer APIs that take a specific subtype (e.g. `fun setOutput(v: VariableName.Output)`) get compile-time direction enforcement.
+   */
   object Variables {
-    const val SUBSCRIPTION_ID: String = "subscriptionId"
+    object EndEventRegistrationCompleted {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+
+    object StartEventRequestReceived {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+
+    object StartEventSubmitRegistrationForm {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+  }
+
+  /**
+   * Sequence flows between BPMN elements.
+   * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+   * Worker code typically does not need these.
+   */
+  object Flows {
+    val FLOW_05_I_3_X_1_Y: BpmnFlow = BpmnFlow(
+          id = "Flow_05i3x1y",
+          sourceRef = "StartEvent_RequestReceived",
+          targetRef = "Activity_SendConfirmationMail",
+        )
+
+    val FLOW_09_CUVZP: BpmnFlow = BpmnFlow(
+          id = "Flow_09cuvzp",
+          sourceRef = "SubProcess_Confirmation",
+          targetRef = "Activity_SendWelcomeMail",
+        )
+
+    val FLOW_0_X_4_EWVB: BpmnFlow = BpmnFlow(
+          id = "Flow_0x4ewvb",
+          sourceRef = "Timer_EveryDay",
+          targetRef = "Activity_SendConfirmationMail",
+        )
+
+    val FLOW_1_BCKM_43: BpmnFlow = BpmnFlow(
+          id = "Flow_1bckm43",
+          sourceRef = "Activity_SendConfirmationMail",
+          targetRef = "Activity_ConfirmRegistration",
+        )
+
+    val FLOW_1_BSB_8_NO: BpmnFlow = BpmnFlow(
+          id = "Flow_1bsb8no",
+          sourceRef = "Activity_AbortRegistration",
+          targetRef = "EndEvent_RegistrationAborted",
+        )
+
+    val FLOW_1_CPWE_57: BpmnFlow = BpmnFlow(
+          id = "Flow_1cpwe57",
+          sourceRef = "Activity_ConfirmRegistration",
+          targetRef = "EndEvent_SubscriptionConfirmed",
+        )
+
+    val FLOW_1_CSFYYZ: BpmnFlow = BpmnFlow(
+          id = "Flow_1csfyyz",
+          sourceRef = "StartEvent_SubmitRegistrationForm",
+          targetRef = "SubProcess_Confirmation",
+        )
+
+    val FLOW_1_I_7_HJID: BpmnFlow = BpmnFlow(
+          id = "Flow_1i7hjid",
+          sourceRef = "Activity_SendWelcomeMail",
+          targetRef = "EndEvent_RegistrationCompleted",
+        )
+
+    val FLOW_1_L_1_LJ_4_M: BpmnFlow = BpmnFlow(
+          id = "Flow_1l1lj4m",
+          sourceRef = "Timer_After3Days",
+          targetRef = "Activity_AbortRegistration",
+        )
+  }
+
+  /**
+   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Intended for tooling and tests, not worker runtime code.
+   */
+  object Relations {
+    val ACTIVITY_ABORT_REGISTRATION: BpmnRelations = BpmnRelations(
+          name = "Abort registration",
+          previousElements = listOf("Timer_After3Days"),
+          followingElements = listOf("EndEvent_RegistrationAborted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val ACTIVITY_CONFIRM_REGISTRATION: BpmnRelations = BpmnRelations(
+          name = "Confirm subscription",
+          previousElements = listOf("Activity_SendConfirmationMail"),
+          followingElements = listOf("EndEvent_SubscriptionConfirmed"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = listOf("Timer_EveryDay"),
+        )
+
+    val ACTIVITY_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send confirmation mail",
+          previousElements = listOf("StartEvent_RequestReceived", "Timer_EveryDay"),
+          followingElements = listOf("Activity_ConfirmRegistration"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val ACTIVITY_SEND_WELCOME_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send Welcome-Mail",
+          previousElements = listOf("SubProcess_Confirmation"),
+          followingElements = listOf("EndEvent_RegistrationCompleted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_REGISTRATION_ABORTED: BpmnRelations = BpmnRelations(
+          name = "Registration aborted",
+          previousElements = listOf("Activity_AbortRegistration"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_REGISTRATION_COMPLETED: BpmnRelations = BpmnRelations(
+          name = "Registration completed",
+          previousElements = listOf("Activity_SendWelcomeMail"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_SUBSCRIPTION_CONFIRMED: BpmnRelations = BpmnRelations(
+          name = "Subscription confirmed",
+          previousElements = listOf("Activity_ConfirmRegistration"),
+          followingElements = emptyList(),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_REQUEST_RECEIVED: BpmnRelations = BpmnRelations(
+          name = "Subscription requested",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_SUBMIT_REGISTRATION_FORM: BpmnRelations = BpmnRelations(
+          name = "Submit newsletter form",
+          previousElements = emptyList(),
+          followingElements = listOf("SubProcess_Confirmation"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SUB_PROCESS_CONFIRMATION: BpmnRelations = BpmnRelations(
+          name = "Subscription Confirmation",
+          previousElements = listOf("StartEvent_SubmitRegistrationForm"),
+          followingElements = listOf("Activity_SendWelcomeMail"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = listOf("Timer_After3Days"),
+        )
+
+    val TIMER_AFTER_3_DAYS: BpmnRelations = BpmnRelations(
+          name = "After 3 days",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_AbortRegistration"),
+          parentId = null,
+          attachedToRef = "SubProcess_Confirmation",
+          attachedElements = emptyList(),
+        )
+
+    val TIMER_EVERY_DAY: BpmnRelations = BpmnRelations(
+          name = "Every day",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = "Activity_ConfirmRegistration",
+          attachedElements = emptyList(),
+        )
   }
 }

--- a/examples/idempotency-pattern/build.gradle.kts
+++ b/examples/idempotency-pattern/build.gradle.kts
@@ -40,7 +40,6 @@ tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
     packagePath = "io.miragon.example.adapter.process"
     outputLanguage = OutputLanguage.KOTLIN
     processEngine = ProcessEngine.ZEEBE
-    useVersioning = false
 }
 
 java {

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/AbortSubscriptionWorker.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/AbortSubscriptionWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.AbortSubscriptionUseCase
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
@@ -18,7 +18,7 @@ class AbortSubscriptionWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_ABORT_REGISTRATION)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_ABORT_REGISTRATION)
     fun abortRegistration(
         job: ActivatedJob,
         @Variable("subscriptionId") subscriptionId: String

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/RegistrationCompletedWorker.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/RegistrationCompletedWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.IncrementSubscriptionCounterUseCase
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
@@ -18,7 +18,7 @@ class RegistrationCompletedWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_REGISTRATION_COMPLETED)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_REGISTRATION_COMPLETED)
     fun handleRegistrationCompleted(
         job: ActivatedJob,
         @Variable("subscriptionId") subscriptionId: String

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendConfirmationMailWorker.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendConfirmationMailWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.SendConfirmationMailUseCase
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
@@ -18,7 +18,7 @@ class SendConfirmationMailWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_CONFIRMATION_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_CONFIRMATION_MAIL)
     fun sendConfirmationMail(
         job: ActivatedJob,
         @Variable("subscriptionId") subscriptionId: String

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.SendWelcomeMailUseCase
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
@@ -18,7 +18,7 @@ class SendWelcomeMailWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_WELCOME_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_WELCOME_MAIL)
     fun sendWelcomeMail(
         job: ActivatedJob,
         @Variable("subscriptionId") subscriptionId: String

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapter.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapter.kt
@@ -2,6 +2,7 @@ package io.miragon.example.adapter.out.zeebe
 
 import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_FORM_SUBMITTED
 import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_SUBSCRIPTION_CONFIRMED
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Variables
 import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.CamundaClient
@@ -15,11 +16,11 @@ class NewsletterSubscriptionProcessAdapter(
 
     override fun submitForm(id: SubscriptionId) {
         val correlationKey = id.value.toString()
-        val variables = mapOf("subscriptionId" to correlationKey)
+        val variables = mapOf(Variables.StartEventSubmitRegistrationForm.SUBSCRIPTION_ID.value to correlationKey)
         val messageId = "$correlationKey-$MESSAGE_FORM_SUBMITTED"
 
         camundaClient.newPublishMessageCommand()
-            .messageName(MESSAGE_FORM_SUBMITTED)
+            .messageName(MESSAGE_FORM_SUBMITTED.value)
             .correlationKey(correlationKey)
             .messageId(messageId)
             .variables(variables)
@@ -33,7 +34,7 @@ class NewsletterSubscriptionProcessAdapter(
         val messageId = "$correlationKey-$MESSAGE_SUBSCRIPTION_CONFIRMED"
 
         camundaClient.newPublishMessageCommand()
-            .messageName(MESSAGE_SUBSCRIPTION_CONFIRMED)
+            .messageName(MESSAGE_SUBSCRIPTION_CONFIRMED.value)
             .correlationKey(correlationKey)
             .messageId(messageId)
             .timeToLive(Duration.ofSeconds(10))

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
@@ -3,48 +3,72 @@
 
 package io.miragon.example.adapter.process
 
+import io.github.emaarco.bpmn.runtime.BpmnEngine
+import io.github.emaarco.bpmn.runtime.BpmnFlow
+import io.github.emaarco.bpmn.runtime.BpmnRelations
+import io.github.emaarco.bpmn.runtime.BpmnTimer
+import io.github.emaarco.bpmn.runtime.ElementId
+import io.github.emaarco.bpmn.runtime.MessageName
+import io.github.emaarco.bpmn.runtime.ProcessId
+import io.github.emaarco.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 
 object NewsletterSubscriptionProcessApi {
-  const val PROCESS_ID: String = "newsletter-subscription"
+  val PROCESS_ID: ProcessId = ProcessId("newsletter-subscription")
 
-  const val PROCESS_ENGINE: String = "ZEEBE"
+  val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
+  /**
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests or when searching for tasks.
+   * Worker runtime code rarely needs these.
+   */
   object Elements {
-    const val ACTIVITY_ABORT_REGISTRATION: String = "Activity_AbortRegistration"
+    val ACTIVITY_ABORT_REGISTRATION: ElementId = ElementId("Activity_AbortRegistration")
 
-    const val ACTIVITY_CONFIRM_REGISTRATION: String = "Activity_ConfirmRegistration"
+    val ACTIVITY_CONFIRM_REGISTRATION: ElementId = ElementId("Activity_ConfirmRegistration")
 
-    const val ACTIVITY_SEND_CONFIRMATION_MAIL: String = "Activity_SendConfirmationMail"
+    val ACTIVITY_SEND_CONFIRMATION_MAIL: ElementId =
+        ElementId("Activity_SendConfirmationMail")
 
-    const val ACTIVITY_SEND_WELCOME_MAIL: String = "Activity_SendWelcomeMail"
+    val ACTIVITY_SEND_WELCOME_MAIL: ElementId = ElementId("Activity_SendWelcomeMail")
 
-    const val END_EVENT_REGISTRATION_ABORTED: String = "EndEvent_RegistrationAborted"
+    val END_EVENT_REGISTRATION_ABORTED: ElementId = ElementId("EndEvent_RegistrationAborted")
 
-    const val END_EVENT_REGISTRATION_COMPLETED: String = "EndEvent_RegistrationCompleted"
+    val END_EVENT_REGISTRATION_COMPLETED: ElementId =
+        ElementId("EndEvent_RegistrationCompleted")
 
-    const val END_EVENT_SUBSCRIPTION_CONFIRMED: String = "EndEvent_SubscriptionConfirmed"
+    val END_EVENT_SUBSCRIPTION_CONFIRMED: ElementId =
+        ElementId("EndEvent_SubscriptionConfirmed")
 
-    const val START_EVENT_REQUEST_RECEIVED: String = "StartEvent_RequestReceived"
+    val START_EVENT_REQUEST_RECEIVED: ElementId = ElementId("StartEvent_RequestReceived")
 
-    const val START_EVENT_SUBMIT_REGISTRATION_FORM: String =
-        "StartEvent_SubmitRegistrationForm"
+    val START_EVENT_SUBMIT_REGISTRATION_FORM: ElementId =
+        ElementId("StartEvent_SubmitRegistrationForm")
 
-    const val SUB_PROCESS_CONFIRMATION: String = "SubProcess_Confirmation"
+    val SUB_PROCESS_CONFIRMATION: ElementId = ElementId("SubProcess_Confirmation")
 
-    const val TIMER_AFTER_3_DAYS: String = "Timer_After3Days"
+    val TIMER_AFTER_3_DAYS: ElementId = ElementId("Timer_After3Days")
 
-    const val TIMER_EVERY_DAY: String = "Timer_EveryDay"
+    val TIMER_EVERY_DAY: ElementId = ElementId("Timer_EveryDay")
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   object Messages {
-    const val MESSAGE_FORM_SUBMITTED: String = "Message_FormSubmitted"
+    val MESSAGE_FORM_SUBMITTED: MessageName = MessageName("Message_FormSubmitted")
 
-    const val MESSAGE_SUBSCRIPTION_CONFIRMED: String = "Message_SubscriptionConfirmed"
+    val MESSAGE_SUBSCRIPTION_CONFIRMED: MessageName =
+        MessageName("Message_SubscriptionConfirmed")
   }
 
-  object TaskTypes {
+  /**
+   * Job worker task types used in `@JobWorker(type = ServiceTasks.X)` annotations.
+   * Kept as `const val String` because annotation arguments must be compile-time constants.
+   */
+  object ServiceTasks {
     const val NEWSLETTER_ABORT_REGISTRATION: String = "newsletter.abortRegistration"
 
     const val NEWSLETTER_REGISTRATION_COMPLETED: String = "newsletter.registrationCompleted"
@@ -58,14 +82,199 @@ object NewsletterSubscriptionProcessApi {
     val TIMER_AFTER_3_DAYS: BpmnTimer = BpmnTimer("Duration", "PT2M30S")
 
     val TIMER_EVERY_DAY: BpmnTimer = BpmnTimer("Duration", "PT1M")
-
-    data class BpmnTimer(
-      val type: String,
-      val timerValue: String,
-    )
   }
 
+  /**
+   * Process variables grouped by the BPMN element that declares them.
+   * Direction is encoded in each variable's wrapper type: `VariableName.Input`, `VariableName.Output`, or `VariableName.InOut` when the variable is both read and written by the same element.
+   * Consumer APIs that take a specific subtype (e.g. `fun setOutput(v: VariableName.Output)`) get compile-time direction enforcement.
+   */
   object Variables {
-    const val SUBSCRIPTION_ID: String = "subscriptionId"
+    object EndEventRegistrationCompleted {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+
+    object StartEventRequestReceived {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+
+    object StartEventSubmitRegistrationForm {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+  }
+
+  /**
+   * Sequence flows between BPMN elements.
+   * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+   * Worker code typically does not need these.
+   */
+  object Flows {
+    val FLOW_05_I_3_X_1_Y: BpmnFlow = BpmnFlow(
+          id = "Flow_05i3x1y",
+          sourceRef = "StartEvent_RequestReceived",
+          targetRef = "Activity_SendConfirmationMail",
+        )
+
+    val FLOW_09_CUVZP: BpmnFlow = BpmnFlow(
+          id = "Flow_09cuvzp",
+          sourceRef = "SubProcess_Confirmation",
+          targetRef = "Activity_SendWelcomeMail",
+        )
+
+    val FLOW_0_X_4_EWVB: BpmnFlow = BpmnFlow(
+          id = "Flow_0x4ewvb",
+          sourceRef = "Timer_EveryDay",
+          targetRef = "Activity_SendConfirmationMail",
+        )
+
+    val FLOW_1_BCKM_43: BpmnFlow = BpmnFlow(
+          id = "Flow_1bckm43",
+          sourceRef = "Activity_SendConfirmationMail",
+          targetRef = "Activity_ConfirmRegistration",
+        )
+
+    val FLOW_1_BSB_8_NO: BpmnFlow = BpmnFlow(
+          id = "Flow_1bsb8no",
+          sourceRef = "Activity_AbortRegistration",
+          targetRef = "EndEvent_RegistrationAborted",
+        )
+
+    val FLOW_1_CPWE_57: BpmnFlow = BpmnFlow(
+          id = "Flow_1cpwe57",
+          sourceRef = "Activity_ConfirmRegistration",
+          targetRef = "EndEvent_SubscriptionConfirmed",
+        )
+
+    val FLOW_1_CSFYYZ: BpmnFlow = BpmnFlow(
+          id = "Flow_1csfyyz",
+          sourceRef = "StartEvent_SubmitRegistrationForm",
+          targetRef = "SubProcess_Confirmation",
+        )
+
+    val FLOW_1_I_7_HJID: BpmnFlow = BpmnFlow(
+          id = "Flow_1i7hjid",
+          sourceRef = "Activity_SendWelcomeMail",
+          targetRef = "EndEvent_RegistrationCompleted",
+        )
+
+    val FLOW_1_L_1_LJ_4_M: BpmnFlow = BpmnFlow(
+          id = "Flow_1l1lj4m",
+          sourceRef = "Timer_After3Days",
+          targetRef = "Activity_AbortRegistration",
+        )
+  }
+
+  /**
+   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Intended for tooling and tests, not worker runtime code.
+   */
+  object Relations {
+    val ACTIVITY_ABORT_REGISTRATION: BpmnRelations = BpmnRelations(
+          name = "Abort registration",
+          previousElements = listOf("Timer_After3Days"),
+          followingElements = listOf("EndEvent_RegistrationAborted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val ACTIVITY_CONFIRM_REGISTRATION: BpmnRelations = BpmnRelations(
+          name = "Confirm subscription",
+          previousElements = listOf("Activity_SendConfirmationMail"),
+          followingElements = listOf("EndEvent_SubscriptionConfirmed"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = listOf("Timer_EveryDay"),
+        )
+
+    val ACTIVITY_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send confirmation mail",
+          previousElements = listOf("StartEvent_RequestReceived", "Timer_EveryDay"),
+          followingElements = listOf("Activity_ConfirmRegistration"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val ACTIVITY_SEND_WELCOME_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send Welcome-Mail",
+          previousElements = listOf("SubProcess_Confirmation"),
+          followingElements = listOf("EndEvent_RegistrationCompleted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_REGISTRATION_ABORTED: BpmnRelations = BpmnRelations(
+          name = "Registration aborted",
+          previousElements = listOf("Activity_AbortRegistration"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_REGISTRATION_COMPLETED: BpmnRelations = BpmnRelations(
+          name = "Registration completed",
+          previousElements = listOf("Activity_SendWelcomeMail"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_SUBSCRIPTION_CONFIRMED: BpmnRelations = BpmnRelations(
+          name = "Subscription confirmed",
+          previousElements = listOf("Activity_ConfirmRegistration"),
+          followingElements = emptyList(),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_REQUEST_RECEIVED: BpmnRelations = BpmnRelations(
+          name = "Subscription requested",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_SUBMIT_REGISTRATION_FORM: BpmnRelations = BpmnRelations(
+          name = "Submit newsletter form",
+          previousElements = emptyList(),
+          followingElements = listOf("SubProcess_Confirmation"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SUB_PROCESS_CONFIRMATION: BpmnRelations = BpmnRelations(
+          name = "Subscription Confirmation",
+          previousElements = listOf("StartEvent_SubmitRegistrationForm"),
+          followingElements = listOf("Activity_SendWelcomeMail"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = listOf("Timer_After3Days"),
+        )
+
+    val TIMER_AFTER_3_DAYS: BpmnRelations = BpmnRelations(
+          name = "After 3 days",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_AbortRegistration"),
+          parentId = null,
+          attachedToRef = "SubProcess_Confirmation",
+          attachedElements = emptyList(),
+        )
+
+    val TIMER_EVERY_DAY: BpmnRelations = BpmnRelations(
+          name = "Every day",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = "Activity_ConfirmRegistration",
+          attachedElements = emptyList(),
+        )
   }
 }

--- a/examples/outbox-pattern/build.gradle.kts
+++ b/examples/outbox-pattern/build.gradle.kts
@@ -40,7 +40,6 @@ tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
     packagePath = "io.miragon.example.adapter.process"
     outputLanguage = OutputLanguage.KOTLIN
     processEngine = ProcessEngine.ZEEBE
-    useVersioning = false
 }
 
 java {

--- a/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/AbortRegistrationWorker.kt
+++ b/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/AbortRegistrationWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.AbortSubscriptionUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -14,7 +14,7 @@ class AbortRegistrationWorker(private val useCase: AbortSubscriptionUseCase) {
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_ABORT_REGISTRATION)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_ABORT_REGISTRATION)
     fun abortRegistration(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job to abort registration: $subscriptionId" }
         useCase.abort(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendConfirmationMailWorker.kt
+++ b/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendConfirmationMailWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.SendConfirmationMailUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -14,7 +14,7 @@ class SendConfirmationMailWorker(private val useCase: SendConfirmationMailUseCas
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_CONFIRMATION_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_CONFIRMATION_MAIL)
     fun sendConfirmationMail(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job to send confirmation mail: $subscriptionId" }
         useCase.sendConfirmationMail(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
+++ b/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.SendWelcomeMailUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -14,7 +14,7 @@ class SendWelcomeMailWorker(private val useCase: SendWelcomeMailUseCase) {
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_WELCOME_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_WELCOME_MAIL)
     fun sendConfirmationMail(@Variable("subscriptionId") subscriptionId: String) {
         log.debug { "Received Zeebe job to send welcome mail: $subscriptionId" }
         useCase.sendWelcomeMail(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/out/db/message/ProcessMessagePersistenceAdapter.kt
+++ b/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/out/db/message/ProcessMessagePersistenceAdapter.kt
@@ -3,6 +3,7 @@ package io.miragon.example.adapter.out.db.message
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_FORM_SUBMITTED
 import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_SUBSCRIPTION_CONFIRMED
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Variables
 import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
 import io.miragon.example.domain.SubscriptionId
 import mu.KotlinLogging
@@ -17,14 +18,14 @@ class ProcessMessagePersistenceAdapter(
     private val objectMapper = ObjectMapper()
 
     override fun submitForm(id: SubscriptionId) {
-        val variables = mapOf("subscriptionId" to id.value.toString())
-        val processMessage = toProcessMessage(MESSAGE_FORM_SUBMITTED, id.value.toString(), variables)
+        val variables = mapOf(Variables.StartEventSubmitRegistrationForm.SUBSCRIPTION_ID.value to id.value.toString())
+        val processMessage = toProcessMessage(MESSAGE_FORM_SUBMITTED.value, id.value.toString(), variables)
         repository.save(processMessage)
     }
 
     override fun confirmSubscription(id: SubscriptionId) {
-        val variables = mapOf("subscriptionId" to id.value.toString())
-        val processMessage = toProcessMessage(MESSAGE_SUBSCRIPTION_CONFIRMED, id.value.toString(), variables)
+        val variables = mapOf(Variables.StartEventSubmitRegistrationForm.SUBSCRIPTION_ID.value to id.value.toString())
+        val processMessage = toProcessMessage(MESSAGE_SUBSCRIPTION_CONFIRMED.value, id.value.toString(), variables)
         repository.save(processMessage)
         log.info { "Saved message for subscription-confirmation $id" }
     }

--- a/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
+++ b/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
@@ -3,48 +3,72 @@
 
 package io.miragon.example.adapter.process
 
+import io.github.emaarco.bpmn.runtime.BpmnEngine
+import io.github.emaarco.bpmn.runtime.BpmnFlow
+import io.github.emaarco.bpmn.runtime.BpmnRelations
+import io.github.emaarco.bpmn.runtime.BpmnTimer
+import io.github.emaarco.bpmn.runtime.ElementId
+import io.github.emaarco.bpmn.runtime.MessageName
+import io.github.emaarco.bpmn.runtime.ProcessId
+import io.github.emaarco.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 
 object NewsletterSubscriptionProcessApi {
-  const val PROCESS_ID: String = "newsletter-subscription"
+  val PROCESS_ID: ProcessId = ProcessId("newsletter-subscription")
 
-  const val PROCESS_ENGINE: String = "ZEEBE"
+  val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
+  /**
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests or when searching for tasks.
+   * Worker runtime code rarely needs these.
+   */
   object Elements {
-    const val ACTIVITY_ABORT_REGISTRATION: String = "Activity_AbortRegistration"
+    val ACTIVITY_ABORT_REGISTRATION: ElementId = ElementId("Activity_AbortRegistration")
 
-    const val ACTIVITY_CONFIRM_REGISTRATION: String = "Activity_ConfirmRegistration"
+    val ACTIVITY_CONFIRM_REGISTRATION: ElementId = ElementId("Activity_ConfirmRegistration")
 
-    const val ACTIVITY_SEND_CONFIRMATION_MAIL: String = "Activity_SendConfirmationMail"
+    val ACTIVITY_SEND_CONFIRMATION_MAIL: ElementId =
+        ElementId("Activity_SendConfirmationMail")
 
-    const val ACTIVITY_SEND_WELCOME_MAIL: String = "Activity_SendWelcomeMail"
+    val ACTIVITY_SEND_WELCOME_MAIL: ElementId = ElementId("Activity_SendWelcomeMail")
 
-    const val END_EVENT_REGISTRATION_ABORTED: String = "EndEvent_RegistrationAborted"
+    val END_EVENT_REGISTRATION_ABORTED: ElementId = ElementId("EndEvent_RegistrationAborted")
 
-    const val END_EVENT_REGISTRATION_COMPLETED: String = "EndEvent_RegistrationCompleted"
+    val END_EVENT_REGISTRATION_COMPLETED: ElementId =
+        ElementId("EndEvent_RegistrationCompleted")
 
-    const val END_EVENT_SUBSCRIPTION_CONFIRMED: String = "EndEvent_SubscriptionConfirmed"
+    val END_EVENT_SUBSCRIPTION_CONFIRMED: ElementId =
+        ElementId("EndEvent_SubscriptionConfirmed")
 
-    const val START_EVENT_REQUEST_RECEIVED: String = "StartEvent_RequestReceived"
+    val START_EVENT_REQUEST_RECEIVED: ElementId = ElementId("StartEvent_RequestReceived")
 
-    const val START_EVENT_SUBMIT_REGISTRATION_FORM: String =
-        "StartEvent_SubmitRegistrationForm"
+    val START_EVENT_SUBMIT_REGISTRATION_FORM: ElementId =
+        ElementId("StartEvent_SubmitRegistrationForm")
 
-    const val SUB_PROCESS_CONFIRMATION: String = "SubProcess_Confirmation"
+    val SUB_PROCESS_CONFIRMATION: ElementId = ElementId("SubProcess_Confirmation")
 
-    const val TIMER_AFTER_3_DAYS: String = "Timer_After3Days"
+    val TIMER_AFTER_3_DAYS: ElementId = ElementId("Timer_After3Days")
 
-    const val TIMER_EVERY_DAY: String = "Timer_EveryDay"
+    val TIMER_EVERY_DAY: ElementId = ElementId("Timer_EveryDay")
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   object Messages {
-    const val MESSAGE_FORM_SUBMITTED: String = "Message_FormSubmitted"
+    val MESSAGE_FORM_SUBMITTED: MessageName = MessageName("Message_FormSubmitted")
 
-    const val MESSAGE_SUBSCRIPTION_CONFIRMED: String = "Message_SubscriptionConfirmed"
+    val MESSAGE_SUBSCRIPTION_CONFIRMED: MessageName =
+        MessageName("Message_SubscriptionConfirmed")
   }
 
-  object TaskTypes {
+  /**
+   * Job worker task types used in `@JobWorker(type = ServiceTasks.X)` annotations.
+   * Kept as `const val String` because annotation arguments must be compile-time constants.
+   */
+  object ServiceTasks {
     const val NEWSLETTER_ABORT_REGISTRATION: String = "newsletter.abortRegistration"
 
     const val NEWSLETTER_REGISTRATION_COMPLETED: String = "newsletter.registrationCompleted"
@@ -58,14 +82,199 @@ object NewsletterSubscriptionProcessApi {
     val TIMER_AFTER_3_DAYS: BpmnTimer = BpmnTimer("Duration", "PT2M30S")
 
     val TIMER_EVERY_DAY: BpmnTimer = BpmnTimer("Duration", "PT1M")
-
-    data class BpmnTimer(
-      val type: String,
-      val timerValue: String,
-    )
   }
 
+  /**
+   * Process variables grouped by the BPMN element that declares them.
+   * Direction is encoded in each variable's wrapper type: `VariableName.Input`, `VariableName.Output`, or `VariableName.InOut` when the variable is both read and written by the same element.
+   * Consumer APIs that take a specific subtype (e.g. `fun setOutput(v: VariableName.Output)`) get compile-time direction enforcement.
+   */
   object Variables {
-    const val SUBSCRIPTION_ID: String = "subscriptionId"
+    object EndEventRegistrationCompleted {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+
+    object StartEventRequestReceived {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+
+    object StartEventSubmitRegistrationForm {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+  }
+
+  /**
+   * Sequence flows between BPMN elements.
+   * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+   * Worker code typically does not need these.
+   */
+  object Flows {
+    val FLOW_05_I_3_X_1_Y: BpmnFlow = BpmnFlow(
+          id = "Flow_05i3x1y",
+          sourceRef = "StartEvent_RequestReceived",
+          targetRef = "Activity_SendConfirmationMail",
+        )
+
+    val FLOW_09_CUVZP: BpmnFlow = BpmnFlow(
+          id = "Flow_09cuvzp",
+          sourceRef = "SubProcess_Confirmation",
+          targetRef = "Activity_SendWelcomeMail",
+        )
+
+    val FLOW_0_X_4_EWVB: BpmnFlow = BpmnFlow(
+          id = "Flow_0x4ewvb",
+          sourceRef = "Timer_EveryDay",
+          targetRef = "Activity_SendConfirmationMail",
+        )
+
+    val FLOW_1_BCKM_43: BpmnFlow = BpmnFlow(
+          id = "Flow_1bckm43",
+          sourceRef = "Activity_SendConfirmationMail",
+          targetRef = "Activity_ConfirmRegistration",
+        )
+
+    val FLOW_1_BSB_8_NO: BpmnFlow = BpmnFlow(
+          id = "Flow_1bsb8no",
+          sourceRef = "Activity_AbortRegistration",
+          targetRef = "EndEvent_RegistrationAborted",
+        )
+
+    val FLOW_1_CPWE_57: BpmnFlow = BpmnFlow(
+          id = "Flow_1cpwe57",
+          sourceRef = "Activity_ConfirmRegistration",
+          targetRef = "EndEvent_SubscriptionConfirmed",
+        )
+
+    val FLOW_1_CSFYYZ: BpmnFlow = BpmnFlow(
+          id = "Flow_1csfyyz",
+          sourceRef = "StartEvent_SubmitRegistrationForm",
+          targetRef = "SubProcess_Confirmation",
+        )
+
+    val FLOW_1_I_7_HJID: BpmnFlow = BpmnFlow(
+          id = "Flow_1i7hjid",
+          sourceRef = "Activity_SendWelcomeMail",
+          targetRef = "EndEvent_RegistrationCompleted",
+        )
+
+    val FLOW_1_L_1_LJ_4_M: BpmnFlow = BpmnFlow(
+          id = "Flow_1l1lj4m",
+          sourceRef = "Timer_After3Days",
+          targetRef = "Activity_AbortRegistration",
+        )
+  }
+
+  /**
+   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Intended for tooling and tests, not worker runtime code.
+   */
+  object Relations {
+    val ACTIVITY_ABORT_REGISTRATION: BpmnRelations = BpmnRelations(
+          name = "Abort registration",
+          previousElements = listOf("Timer_After3Days"),
+          followingElements = listOf("EndEvent_RegistrationAborted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val ACTIVITY_CONFIRM_REGISTRATION: BpmnRelations = BpmnRelations(
+          name = "Confirm subscription",
+          previousElements = listOf("Activity_SendConfirmationMail"),
+          followingElements = listOf("EndEvent_SubscriptionConfirmed"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = listOf("Timer_EveryDay"),
+        )
+
+    val ACTIVITY_SEND_CONFIRMATION_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send confirmation mail",
+          previousElements = listOf("StartEvent_RequestReceived", "Timer_EveryDay"),
+          followingElements = listOf("Activity_ConfirmRegistration"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val ACTIVITY_SEND_WELCOME_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send Welcome-Mail",
+          previousElements = listOf("SubProcess_Confirmation"),
+          followingElements = listOf("EndEvent_RegistrationCompleted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_REGISTRATION_ABORTED: BpmnRelations = BpmnRelations(
+          name = "Registration aborted",
+          previousElements = listOf("Activity_AbortRegistration"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_REGISTRATION_COMPLETED: BpmnRelations = BpmnRelations(
+          name = "Registration completed",
+          previousElements = listOf("Activity_SendWelcomeMail"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_SUBSCRIPTION_CONFIRMED: BpmnRelations = BpmnRelations(
+          name = "Subscription confirmed",
+          previousElements = listOf("Activity_ConfirmRegistration"),
+          followingElements = emptyList(),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_REQUEST_RECEIVED: BpmnRelations = BpmnRelations(
+          name = "Subscription requested",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_SUBMIT_REGISTRATION_FORM: BpmnRelations = BpmnRelations(
+          name = "Submit newsletter form",
+          previousElements = emptyList(),
+          followingElements = listOf("SubProcess_Confirmation"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SUB_PROCESS_CONFIRMATION: BpmnRelations = BpmnRelations(
+          name = "Subscription Confirmation",
+          previousElements = listOf("StartEvent_SubmitRegistrationForm"),
+          followingElements = listOf("Activity_SendWelcomeMail"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = listOf("Timer_After3Days"),
+        )
+
+    val TIMER_AFTER_3_DAYS: BpmnRelations = BpmnRelations(
+          name = "After 3 days",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_AbortRegistration"),
+          parentId = null,
+          attachedToRef = "SubProcess_Confirmation",
+          attachedElements = emptyList(),
+        )
+
+    val TIMER_EVERY_DAY: BpmnRelations = BpmnRelations(
+          name = "Every day",
+          previousElements = emptyList(),
+          followingElements = listOf("Activity_SendConfirmationMail"),
+          parentId = "SubProcess_Confirmation",
+          attachedToRef = "Activity_ConfirmRegistration",
+          attachedElements = emptyList(),
+        )
   }
 }

--- a/examples/saga-pattern/build.gradle.kts
+++ b/examples/saga-pattern/build.gradle.kts
@@ -40,7 +40,6 @@ tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
     packagePath = "io.miragon.example.adapter.process"
     outputLanguage = OutputLanguage.KOTLIN
     processEngine = ProcessEngine.ZEEBE
-    useVersioning = false
 }
 
 java {

--- a/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/CancelReservationWorker.kt
+++ b/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/CancelReservationWorker.kt
@@ -1,7 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.TaskTypes
-import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.Variables
+import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.CancelReservationUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -17,9 +16,9 @@ class CancelReservationWorker(
 
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_CANCEL_SPOT)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_CANCEL_SPOT)
     fun cancelReservation(
-        @Variable(Variables.SUBSCRIPTION_ID) subscriptionId: String
+        @Variable("subscriptionId") subscriptionId: String
     ) {
         log.debug { "Received task to cancel reservation: $subscriptionId" }
         useCase.cancelReservation(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/ProcessPaymentWorker.kt
+++ b/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/ProcessPaymentWorker.kt
@@ -1,6 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.TaskTypes
+import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.Variables
 import io.miragon.example.application.port.`in`.ProcessPaymentUseCase
 import io.miragon.example.domain.SubscriptionId
@@ -16,12 +16,12 @@ class ProcessPaymentWorker(
 ) {
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_CONFIRMATION_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_CONFIRMATION_MAIL)
     fun processPayment(
-        @Variable(Variables.SUBSCRIPTION_ID) subscriptionId: String
+        @Variable("subscriptionId") subscriptionId: String
     ): Map<String, Boolean> {
         log.debug { "Received Zeebe job to process payment: $subscriptionId" }
         val paymentSuccessful = useCase.processPayment(SubscriptionId(UUID.fromString(subscriptionId)))
-        return mapOf("paymentSuccessful" to paymentSuccessful)
+        return mapOf(Variables.ServiceTaskProcessPayment.PAYMENT_SUCCESSFUL.value to paymentSuccessful)
     }
 }

--- a/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/ReserveSpotWorker.kt
+++ b/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/ReserveSpotWorker.kt
@@ -1,7 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.TaskTypes
-import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.Variables
+import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.ReserveSpotUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -16,9 +15,9 @@ class ReserveSpotWorker(
 ) {
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_RESERVE_SPOT)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_RESERVE_SPOT)
     fun reserveSpot(
-        @Variable(Variables.SUBSCRIPTION_ID) subscriptionId: String
+        @Variable("subscriptionId") subscriptionId: String
     ) {
         log.debug { "Received Zeebe job to reserve spot: $subscriptionId" }
         useCase.reserveSpot(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
+++ b/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/in/zeebe/SendWelcomeMailWorker.kt
@@ -1,7 +1,6 @@
 package io.miragon.example.adapter.`in`.zeebe
 
-import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.TaskTypes
-import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.Variables
+import io.miragon.example.adapter.process.PayedNewsletterSubscriptionProcessApi.ServiceTasks
 import io.miragon.example.application.port.`in`.SendWelcomeMailUseCase
 import io.miragon.example.domain.SubscriptionId
 import io.camunda.client.annotation.JobWorker
@@ -16,9 +15,9 @@ class SendWelcomeMailWorker(
 ) {
     private val log = KotlinLogging.logger {}
 
-    @JobWorker(type = TaskTypes.NEWSLETTER_SEND_WELCOME_MAIL)
+    @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_WELCOME_MAIL)
     fun sendWelcomeMail(
-        @Variable(Variables.SUBSCRIPTION_ID) subscriptionId: String
+        @Variable("subscriptionId") subscriptionId: String
     ) {
         log.debug { "Received Zeebe job to send welcome mail: $subscriptionId" }
         useCase.sendWelcomeMail(SubscriptionId(UUID.fromString(subscriptionId)))

--- a/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/out/zeebe/PayedNewsletterProcessAdapter.kt
+++ b/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/out/zeebe/PayedNewsletterProcessAdapter.kt
@@ -17,10 +17,10 @@ class PayedNewsletterProcessAdapter(
 
     override fun submitForm(id: SubscriptionId) {
         val messageName = Messages.MESSAGE_FORM_SUBMITTED
-        val variables = mapOf(Variables.SUBSCRIPTION_ID to id.value.toString())
+        val variables = mapOf(Variables.StartEventSubmitForm.SUBSCRIPTION_ID.value to id.value.toString())
         log.info { "Publishing message $messageName with variables $variables" }
         camundaClient.newPublishMessageCommand()
-            .messageName(messageName)
+            .messageName(messageName.value)
             .withoutCorrelationKey()
             .variables(variables)
             .send()

--- a/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/process/PayedNewsletterSubscriptionProcessApi.kt
+++ b/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/process/PayedNewsletterSubscriptionProcessApi.kt
@@ -3,41 +3,60 @@
 
 package io.miragon.example.adapter.process
 
+import io.github.emaarco.bpmn.runtime.BpmnEngine
+import io.github.emaarco.bpmn.runtime.BpmnFlow
+import io.github.emaarco.bpmn.runtime.BpmnRelations
+import io.github.emaarco.bpmn.runtime.ElementId
+import io.github.emaarco.bpmn.runtime.MessageName
+import io.github.emaarco.bpmn.runtime.ProcessId
+import io.github.emaarco.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 
 object PayedNewsletterSubscriptionProcessApi {
-  const val PROCESS_ID: String = "payed-newsletter-subscription"
+  val PROCESS_ID: ProcessId = ProcessId("payed-newsletter-subscription")
 
-  const val PROCESS_ENGINE: String = "ZEEBE"
+  val PROCESS_ENGINE: BpmnEngine = BpmnEngine.ZEEBE
 
+  /**
+   * BPMN element ids as declared in the source model.
+   * Typically used in process-level tests or when searching for tasks.
+   * Worker runtime code rarely needs these.
+   */
   object Elements {
-    const val END_EVENT_PAYMENT_FAILED: String = "endEvent_paymentFailed"
+    val END_EVENT_PAYMENT_FAILED: ElementId = ElementId("endEvent_paymentFailed")
 
-    const val END_EVENT_REGISTRATION_COMPLETED: String = "endEvent_registrationCompleted"
+    val END_EVENT_REGISTRATION_COMPLETED: ElementId =
+        ElementId("endEvent_registrationCompleted")
 
-    const val EVENT_PAYMENT_FAILED: String = "event_paymentFailed"
+    val EVENT_PAYMENT_FAILED: ElementId = ElementId("event_paymentFailed")
 
-    const val GATEWAY_PAYMENT_SUCCESSFUL: String = "gateway_paymentSuccessful"
+    val GATEWAY_PAYMENT_SUCCESSFUL: ElementId = ElementId("gateway_paymentSuccessful")
 
-    const val SERVICE_TASK_CANCEL_RESERVATION: String = "serviceTask_cancelReservation"
+    val SERVICE_TASK_CANCEL_RESERVATION: ElementId =
+        ElementId("serviceTask_cancelReservation")
 
-    const val SERVICE_TASK_PROCESS_PAYMENT: String = "serviceTask_processPayment"
+    val SERVICE_TASK_PROCESS_PAYMENT: ElementId = ElementId("serviceTask_processPayment")
 
-    const val SERVICE_TASK_RESERVE_SPOT: String = "serviceTask_reserveSpot"
+    val SERVICE_TASK_RESERVE_SPOT: ElementId = ElementId("serviceTask_reserveSpot")
 
-    const val SERVICE_TASK_SEND_WELCOME_MAIL: String = "serviceTask_sendWelcomeMail"
+    val SERVICE_TASK_SEND_WELCOME_MAIL: ElementId = ElementId("serviceTask_sendWelcomeMail")
 
-    const val START_EVENT_SUBMIT_FORM: String = "startEvent_submitForm"
+    val START_EVENT_SUBMIT_FORM: ElementId = ElementId("startEvent_submitForm")
   }
 
+  /**
+   * BPMN message names used to correlate messages to running process instances.
+   */
   object Messages {
-    const val MESSAGE_FORM_SUBMITTED: String = "Message_FormSubmitted"
-
-    const val MESSAGE_SUBSCRIPTION_CONFIRMED: String = "Message_SubscriptionConfirmed"
+    val MESSAGE_FORM_SUBMITTED: MessageName = MessageName("Message_FormSubmitted")
   }
 
-  object TaskTypes {
+  /**
+   * Job worker task types used in `@JobWorker(type = ServiceTasks.X)` annotations.
+   * Kept as `const val String` because annotation arguments must be compile-time constants.
+   */
+  object ServiceTasks {
     const val NEWSLETTER_CANCEL_SPOT: String = "newsletter.cancelSpot"
 
     const val NEWSLETTER_SEND_CONFIRMATION_MAIL: String = "newsletter.sendConfirmationMail"
@@ -47,9 +66,170 @@ object PayedNewsletterSubscriptionProcessApi {
     const val NEWSLETTER_SEND_WELCOME_MAIL: String = "newsletter.sendWelcomeMail"
   }
 
-  object Variables {
-    const val PAYMENT_SUCCESSFUL: String = "paymentSuccessful"
+  object Compensations {
+    val END_EVENT_PAYMENT_FAILED: ElementId = ElementId("endEvent_paymentFailed")
 
-    const val SUBSCRIPTION_ID: String = "subscriptionId"
+    val EVENT_PAYMENT_FAILED: ElementId = ElementId("event_paymentFailed")
+  }
+
+  /**
+   * Process variables grouped by the BPMN element that declares them.
+   * Direction is encoded in each variable's wrapper type: `VariableName.Input`, `VariableName.Output`, or `VariableName.InOut` when the variable is both read and written by the same element.
+   * Consumer APIs that take a specific subtype (e.g. `fun setOutput(v: VariableName.Output)`) get compile-time direction enforcement.
+   */
+  object Variables {
+    object ServiceTaskCancelReservation {
+      val SUBSCRIPTION_ID: VariableName.Input = VariableName.Input("subscriptionId")
+    }
+
+    object ServiceTaskProcessPayment {
+      val PAYMENT_SUCCESSFUL: VariableName.Output = VariableName.Output("paymentSuccessful")
+
+      val SUBSCRIPTION_ID: VariableName.Input = VariableName.Input("subscriptionId")
+    }
+
+    object ServiceTaskReserveSpot {
+      val SUBSCRIPTION_ID: VariableName.Input = VariableName.Input("subscriptionId")
+    }
+
+    object ServiceTaskSendWelcomeMail {
+      val SUBSCRIPTION_ID: VariableName.Input = VariableName.Input("subscriptionId")
+    }
+
+    object StartEventSubmitForm {
+      val SUBSCRIPTION_ID: VariableName.Output = VariableName.Output("subscriptionId")
+    }
+  }
+
+  /**
+   * Sequence flows between BPMN elements.
+   * Mainly useful for process-model tooling, tests, and AI-agent consumers reasoning about the process shape.
+   * Worker code typically does not need these.
+   */
+  object Flows {
+    val FLOW_0_MD_8_PXO: BpmnFlow = BpmnFlow(
+          id = "Flow_0md8pxo",
+          sourceRef = "startEvent_submitForm",
+          targetRef = "serviceTask_reserveSpot",
+        )
+
+    val FLOW_1_BCCPVR: BpmnFlow = BpmnFlow(
+          id = "Flow_1bccpvr",
+          sourceRef = "serviceTask_processPayment",
+          targetRef = "gateway_paymentSuccessful",
+        )
+
+    val FLOW_1_GAHADA: BpmnFlow = BpmnFlow(
+          id = "Flow_1gahada",
+          sourceRef = "gateway_paymentSuccessful",
+          targetRef = "endEvent_paymentFailed",
+          condition = $$"""=paymentSuccessful = false""",
+        )
+
+    val FLOW_1_LXG_97_J: BpmnFlow = BpmnFlow(
+          id = "Flow_1lxg97j",
+          sourceRef = "gateway_paymentSuccessful",
+          targetRef = "serviceTask_sendWelcomeMail",
+          isDefault = true,
+        )
+
+    val FLOW_1_PM_19_TY: BpmnFlow = BpmnFlow(
+          id = "Flow_1pm19ty",
+          sourceRef = "serviceTask_reserveSpot",
+          targetRef = "serviceTask_processPayment",
+        )
+
+    val FLOW_1_W_1_JP_6_Q: BpmnFlow = BpmnFlow(
+          id = "Flow_1w1jp6q",
+          sourceRef = "serviceTask_sendWelcomeMail",
+          targetRef = "endEvent_registrationCompleted",
+        )
+  }
+
+  /**
+   * Per-element graph metadata (previousElements / followingElements / parentId / boundary attachments).
+   * Intended for tooling and tests, not worker runtime code.
+   */
+  object Relations {
+    val END_EVENT_PAYMENT_FAILED: BpmnRelations = BpmnRelations(
+          name = "Payment failed",
+          previousElements = listOf("gateway_paymentSuccessful"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val END_EVENT_REGISTRATION_COMPLETED: BpmnRelations = BpmnRelations(
+          name = "Registration completed",
+          previousElements = listOf("serviceTask_sendWelcomeMail"),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val EVENT_PAYMENT_FAILED: BpmnRelations = BpmnRelations(
+          name = "Payment failed",
+          previousElements = emptyList(),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = "serviceTask_reserveSpot",
+          attachedElements = emptyList(),
+        )
+
+    val GATEWAY_PAYMENT_SUCCESSFUL: BpmnRelations = BpmnRelations(
+          name = "Payment successful?",
+          previousElements = listOf("serviceTask_processPayment"),
+          followingElements = listOf("serviceTask_sendWelcomeMail", "endEvent_paymentFailed"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SERVICE_TASK_CANCEL_RESERVATION: BpmnRelations = BpmnRelations(
+          name = "Cancel reservation",
+          previousElements = emptyList(),
+          followingElements = emptyList(),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SERVICE_TASK_PROCESS_PAYMENT: BpmnRelations = BpmnRelations(
+          name = "Process payment",
+          previousElements = listOf("serviceTask_reserveSpot"),
+          followingElements = listOf("gateway_paymentSuccessful"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val SERVICE_TASK_RESERVE_SPOT: BpmnRelations = BpmnRelations(
+          name = "Reserve spot",
+          previousElements = listOf("startEvent_submitForm"),
+          followingElements = listOf("serviceTask_processPayment"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = listOf("event_paymentFailed"),
+        )
+
+    val SERVICE_TASK_SEND_WELCOME_MAIL: BpmnRelations = BpmnRelations(
+          name = "Send Welcome-Mail",
+          previousElements = listOf("gateway_paymentSuccessful"),
+          followingElements = listOf("endEvent_registrationCompleted"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
+
+    val START_EVENT_SUBMIT_FORM: BpmnRelations = BpmnRelations(
+          name = "Submit newsletter form",
+          previousElements = emptyList(),
+          followingElements = listOf("serviceTask_reserveSpot"),
+          parentId = null,
+          attachedToRef = null,
+          attachedElements = emptyList(),
+        )
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,4 +47,4 @@ kotlinJpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin_vers
 kotlinKapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin_version" }
 springframework = { id = "org.springframework.boot", version.ref = "spring_version" }
 springDependency = { id = "io.spring.dependency-management", version.ref = "spring_dependency_version" }
-bpmnToCode = { id = "io.github.emaarco.bpmn-to-code-gradle", version = "1.0.0" }
+bpmnToCode = { id = "io.github.emaarco.bpmn-to-code-gradle", version = "2.0.3" }


### PR DESCRIPTION
## Summary
- Upgrades `bpmn-to-code` Gradle plugin from v1.0.0 to v2.0.3
- Removes deprecated `useVersioning` config from all example build files
- Regenerates all `ProcessApi` files and migrates consumer code to the v2 API shape

## Current state
Plugin was pinned at v1.0.0, using the removed `TaskTypes` object and flat `Variables` constants.

## Desired state
All examples compile and build cleanly against v2.0.3 with typed wrappers (`ServiceTasks`, `MessageName`, `VariableName`, etc.).

## What changed
- `TaskTypes` → `ServiceTasks` in all worker imports and `@JobWorker` annotations
- `MessageName` unwrapped with `.value` where Camunda client expects `String`
- Adapter map keys and worker output maps use typed variable constants (`.value`) instead of string literals
- `useVersioning = false` removed from all `build.gradle.kts` files