### PR TITLE
test: add unit tests for example scenarios

### DIFF
--- a/examples/after-transaction/src/test/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapterTest.kt
+++ b/examples/after-transaction/src/test/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapterTest.kt
@@ -1,0 +1,59 @@
+package io.miragon.example.adapter.out.zeebe
+
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_FORM_SUBMITTED
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_SUBSCRIPTION_CONFIRMED
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Variables
+import io.miragon.example.domain.SubscriptionId
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class NewsletterSubscriptionProcessAdapterTest {
+
+    private val engineApi = mockk<ProcessEngineApi>()
+    private val underTest = NewsletterSubscriptionProcessAdapter(engineApi)
+
+    @Test
+    fun `should start process via message when submitting form`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val expectedVariables = mapOf(
+            Variables.StartEventSubmitRegistrationForm.SUBSCRIPTION_ID.value to subscriptionId.value.toString()
+        )
+
+        every { engineApi.startProcessViaMessage(any(), any(), any()) } returns mockk()
+
+        // When
+        underTest.submitForm(subscriptionId)
+
+        // Then
+        verify(exactly = 1) {
+            engineApi.startProcessViaMessage(
+                messageName = MESSAGE_FORM_SUBMITTED.value,
+                correlationId = subscriptionId.value.toString(),
+                variables = expectedVariables
+            )
+        }
+        confirmVerified(engineApi)
+    }
+
+    @Test
+    fun `should send message when confirming subscription`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+
+        every { engineApi.sendMessage(any(), any(), any()) } returns mockk()
+
+        // When
+        underTest.confirmSubscription(subscriptionId)
+
+        // Then
+        verify(exactly = 1) {
+            engineApi.sendMessage(
+                messageName = MESSAGE_SUBSCRIPTION_CONFIRMED.value,
+                correlationId = subscriptionId.value.toString()
+            )
+        }
+        confirmVerified(engineApi)
+    }
+}

--- a/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
+++ b/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
@@ -1,0 +1,39 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class AbortSubscriptionServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val underTest = AbortSubscriptionService(repository)
+
+    @Test
+    fun `should abort subscription registration`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+        every { repository.save(any<NewsletterSubscription>()) } returns mockk()
+
+        // When
+        underTest.abort(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        verify(exactly = 1) { repository.save(any()) }
+        confirmVerified(repository)
+    }
+}

--- a/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/ConfirmSubscriptionServiceTest.kt
+++ b/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/ConfirmSubscriptionServiceTest.kt
@@ -1,0 +1,43 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class ConfirmSubscriptionServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val processPort = mockk<NewsletterSubscriptionProcess>()
+    private val underTest = ConfirmSubscriptionService(repository, processPort)
+
+    @Test
+    fun `should confirm subscription and notify process`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+        every { repository.save(any<NewsletterSubscription>()) } returns mockk()
+        every { processPort.confirmSubscription(subscriptionId) } just Runs
+
+        // When
+        underTest.confirm(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { processPort.confirmSubscription(subscriptionId) }
+        confirmVerified(repository, processPort)
+    }
+}

--- a/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
+++ b/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class SendConfirmationMailServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val underTest = SendConfirmationMailService(repository)
+
+    @Test
+    fun `should find subscription and send confirmation mail`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+
+        // When
+        underTest.sendConfirmationMail(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        confirmVerified(repository)
+    }
+}

--- a/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
+++ b/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class SendWelcomeMailServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val underTest = SendWelcomeMailService(repository)
+
+    @Test
+    fun `should find subscription and send welcome mail`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+
+        // When
+        underTest.sendWelcomeMail(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        confirmVerified(repository)
+    }
+}

--- a/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/SubscribeToNewsletterServiceTest.kt
+++ b/examples/after-transaction/src/test/kotlin/io/miragon/example/application/service/SubscribeToNewsletterServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.`in`.SubscribeToNewsletterUseCase
+import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class SubscribeToNewsletterServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val processPort = mockk<NewsletterSubscriptionProcess>()
+    private val underTest = SubscribeToNewsletterService(repository, processPort)
+
+    @Test
+    fun `should create subscription and notify process when subscribing to newsletter`() {
+        // Given
+        val command = SubscribeToNewsletterUseCase.Command(
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletterId = NewsletterId(UUID.randomUUID())
+        )
+
+        every { repository.save(any<NewsletterSubscription>()) } returns mockk()
+        every { processPort.submitForm(any()) } just Runs
+
+        // When
+        val subscriptionId = underTest.subscribe(command)
+
+        // Then
+        verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { processPort.submitForm(subscriptionId) }
+        confirmVerified(repository, processPort)
+    }
+}

--- a/examples/base-scenario/src/test/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapterTest.kt
+++ b/examples/base-scenario/src/test/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapterTest.kt
@@ -1,0 +1,74 @@
+package io.miragon.example.adapter.out.zeebe
+
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_FORM_SUBMITTED
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_SUBSCRIPTION_CONFIRMED
+import io.miragon.example.domain.SubscriptionId
+import io.camunda.client.CamundaClient
+import io.camunda.client.api.response.PublishMessageResponse
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class NewsletterSubscriptionProcessAdapterTest {
+
+    private val camundaClient = mockk<CamundaClient>(relaxed = true)
+    private val underTest = NewsletterSubscriptionProcessAdapter(camundaClient)
+
+    @Test
+    fun `should publish form submitted message when submitting form`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val response = mockk<PublishMessageResponse>()
+
+        every {
+            camundaClient.newPublishMessageCommand()
+                .messageName(MESSAGE_FORM_SUBMITTED.value)
+                .withoutCorrelationKey()
+                .variables(any<Map<String, Any>>())
+                .send()
+                .join()
+        } returns response
+
+        // When
+        underTest.submitForm(subscriptionId)
+
+        // Then
+        verify(exactly = 1) {
+            camundaClient.newPublishMessageCommand()
+                .messageName(MESSAGE_FORM_SUBMITTED.value)
+                .withoutCorrelationKey()
+                .variables(any<Map<String, Any>>())
+                .send()
+                .join()
+        }
+    }
+
+    @Test
+    fun `should publish subscription confirmed message when confirming subscription`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val response = mockk<PublishMessageResponse>()
+
+        every {
+            camundaClient.newPublishMessageCommand()
+                .messageName(MESSAGE_SUBSCRIPTION_CONFIRMED.value)
+                .correlationKey(subscriptionId.value.toString())
+                .timeToLive(any())
+                .send()
+                .join()
+        } returns response
+
+        // When
+        underTest.confirmSubscription(subscriptionId)
+
+        // Then
+        verify(exactly = 1) {
+            camundaClient.newPublishMessageCommand()
+                .messageName(MESSAGE_SUBSCRIPTION_CONFIRMED.value)
+                .correlationKey(subscriptionId.value.toString())
+                .timeToLive(any())
+                .send()
+                .join()
+        }
+    }
+}

--- a/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
+++ b/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
@@ -1,0 +1,39 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class AbortSubscriptionServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val underTest = AbortSubscriptionService(repository)
+
+    @Test
+    fun `should abort subscription registration`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+        every { repository.save(any<NewsletterSubscription>()) } returns mockk()
+
+        // When
+        underTest.abort(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        verify(exactly = 1) { repository.save(any()) }
+        confirmVerified(repository)
+    }
+}

--- a/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/ConfirmSubscriptionServiceTest.kt
+++ b/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/ConfirmSubscriptionServiceTest.kt
@@ -1,0 +1,43 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class ConfirmSubscriptionServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val processPort = mockk<NewsletterSubscriptionProcess>()
+    private val underTest = ConfirmSubscriptionService(repository, processPort)
+
+    @Test
+    fun `should confirm subscription and notify process`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+        every { repository.save(any<NewsletterSubscription>()) } returns mockk()
+        every { processPort.confirmSubscription(subscriptionId) } just Runs
+
+        // When
+        underTest.confirm(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { processPort.confirmSubscription(subscriptionId) }
+        confirmVerified(repository, processPort)
+    }
+}

--- a/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterServiceTest.kt
+++ b/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterServiceTest.kt
@@ -1,0 +1,32 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.SubscriptionCounterRepository
+import io.miragon.example.domain.SubscriptionCounter
+import io.miragon.example.domain.SubscriptionId
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class IncrementSubscriptionCounterServiceTest {
+
+    private val counterRepository = mockk<SubscriptionCounterRepository>()
+    private val underTest = IncrementSubscriptionCounterService(counterRepository)
+
+    @Test
+    fun `should increment subscription counter`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val counter = SubscriptionCounter(count = 3)
+
+        every { counterRepository.find() } returns counter
+        every { counterRepository.save(any()) } just Runs
+
+        // When
+        underTest.incrementCounter(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { counterRepository.find() }
+        verify(exactly = 1) { counterRepository.save(SubscriptionCounter(count = 4)) }
+        confirmVerified(counterRepository)
+    }
+}

--- a/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
+++ b/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class SendConfirmationMailServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val underTest = SendConfirmationMailService(repository)
+
+    @Test
+    fun `should find subscription and send confirmation mail`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+
+        // When
+        underTest.sendConfirmationMail(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        confirmVerified(repository)
+    }
+}

--- a/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
+++ b/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class SendWelcomeMailServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val underTest = SendWelcomeMailService(repository)
+
+    @Test
+    fun `should find subscription and send welcome mail`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+
+        // When
+        underTest.sendWelcomeMail(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        confirmVerified(repository)
+    }
+}

--- a/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/SubscribeToNewsletterServiceTest.kt
+++ b/examples/base-scenario/src/test/kotlin/io/miragon/example/application/service/SubscribeToNewsletterServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.`in`.SubscribeToNewsletterUseCase
+import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class SubscribeToNewsletterServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val processPort = mockk<NewsletterSubscriptionProcess>()
+    private val underTest = SubscribeToNewsletterService(repository, processPort)
+
+    @Test
+    fun `should create subscription and notify process when subscribing to newsletter`() {
+        // Given
+        val command = SubscribeToNewsletterUseCase.Command(
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletterId = NewsletterId(UUID.randomUUID())
+        )
+
+        every { repository.save(any<NewsletterSubscription>()) } returns mockk()
+        every { processPort.submitForm(any()) } just Runs
+
+        // When
+        val subscriptionId = underTest.subscribe(command)
+
+        // Then
+        verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { processPort.submitForm(subscriptionId) }
+        confirmVerified(repository, processPort)
+    }
+}

--- a/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/adapter/in/zeebe/RegistrationCompletedWorkerTest.kt
+++ b/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/adapter/in/zeebe/RegistrationCompletedWorkerTest.kt
@@ -1,0 +1,35 @@
+package io.miragon.example.adapter.`in`.zeebe
+
+import io.miragon.example.application.port.`in`.IncrementSubscriptionCounterUseCase
+import io.miragon.example.domain.OperationId
+import io.miragon.example.domain.SubscriptionId
+import io.camunda.client.api.response.ActivatedJob
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class RegistrationCompletedWorkerTest {
+
+    private val useCase = mockk<IncrementSubscriptionCounterUseCase>()
+    private val underTest = RegistrationCompletedWorker(useCase)
+
+    @Test
+    fun `should increment counter with operation id when registration completed job is received`() {
+        // Given
+        val subscriptionIdString = "123e4567-e89b-12d3-a456-426614174000"
+        val elementId = "Activity_RegistrationCompleted"
+        val subscriptionId = SubscriptionId(UUID.fromString(subscriptionIdString))
+        val operationId = OperationId("$subscriptionIdString-$elementId")
+
+        val activatedJob = mockk<ActivatedJob>(relaxed = true)
+        every { activatedJob.elementId } returns elementId
+
+        every { useCase.incrementCounter(subscriptionId, operationId) } just Runs
+
+        // When
+        underTest.handleRegistrationCompleted(activatedJob, subscriptionIdString)
+
+        // Then
+        verify(exactly = 1) { useCase.incrementCounter(subscriptionId, operationId) }
+    }
+}

--- a/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapterTest.kt
+++ b/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/adapter/out/zeebe/NewsletterSubscriptionProcessAdapterTest.kt
@@ -1,0 +1,84 @@
+package io.miragon.example.adapter.out.zeebe
+
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_FORM_SUBMITTED
+import io.miragon.example.adapter.process.NewsletterSubscriptionProcessApi.Messages.MESSAGE_SUBSCRIPTION_CONFIRMED
+import io.miragon.example.domain.SubscriptionId
+import io.camunda.client.CamundaClient
+import io.camunda.client.api.response.PublishMessageResponse
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class NewsletterSubscriptionProcessAdapterTest {
+
+    private val camundaClient = mockk<CamundaClient>(relaxed = true)
+    private val underTest = NewsletterSubscriptionProcessAdapter(camundaClient)
+
+    @Test
+    fun `should publish form submitted message with message id when submitting form`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val correlationKey = subscriptionId.value.toString()
+        val expectedMessageId = "$correlationKey-$MESSAGE_FORM_SUBMITTED"
+        val response = mockk<PublishMessageResponse>()
+
+        every {
+            camundaClient.newPublishMessageCommand()
+                .messageName(MESSAGE_FORM_SUBMITTED.value)
+                .correlationKey(correlationKey)
+                .messageId(expectedMessageId)
+                .variables(any<Map<String, Any>>())
+                .timeToLive(any())
+                .send()
+                .join()
+        } returns response
+
+        // When
+        underTest.submitForm(subscriptionId)
+
+        // Then
+        verify(exactly = 1) {
+            camundaClient.newPublishMessageCommand()
+                .messageName(MESSAGE_FORM_SUBMITTED.value)
+                .correlationKey(correlationKey)
+                .messageId(expectedMessageId)
+                .variables(any<Map<String, Any>>())
+                .timeToLive(any())
+                .send()
+                .join()
+        }
+    }
+
+    @Test
+    fun `should publish subscription confirmed message with message id when confirming subscription`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val correlationKey = subscriptionId.value.toString()
+        val expectedMessageId = "$correlationKey-$MESSAGE_SUBSCRIPTION_CONFIRMED"
+        val response = mockk<PublishMessageResponse>()
+
+        every {
+            camundaClient.newPublishMessageCommand()
+                .messageName(MESSAGE_SUBSCRIPTION_CONFIRMED.value)
+                .correlationKey(correlationKey)
+                .messageId(expectedMessageId)
+                .timeToLive(any())
+                .send()
+                .join()
+        } returns response
+
+        // When
+        underTest.confirmSubscription(subscriptionId)
+
+        // Then
+        verify(exactly = 1) {
+            camundaClient.newPublishMessageCommand()
+                .messageName(MESSAGE_SUBSCRIPTION_CONFIRMED.value)
+                .correlationKey(correlationKey)
+                .messageId(expectedMessageId)
+                .timeToLive(any())
+                .send()
+                .join()
+        }
+    }
+}

--- a/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterServiceTest.kt
+++ b/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterServiceTest.kt
@@ -1,0 +1,59 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.ProcessedOperationRepository
+import io.miragon.example.application.port.out.SubscriptionCounterRepository
+import io.miragon.example.domain.OperationId
+import io.miragon.example.domain.SubscriptionCounter
+import io.miragon.example.domain.SubscriptionId
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class IncrementSubscriptionCounterServiceTest {
+
+    private val counterRepository = mockk<SubscriptionCounterRepository>()
+    private val processedOperationRepository = mockk<ProcessedOperationRepository>()
+    private val underTest = IncrementSubscriptionCounterService(counterRepository, processedOperationRepository)
+
+    @Test
+    fun `should increment counter when operation is not processed yet`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val operationId = OperationId("${subscriptionId.value}-Activity_RegistrationCompleted")
+        val counter = SubscriptionCounter(count = 5)
+
+        every { processedOperationRepository.existsById(operationId) } returns false
+        every { counterRepository.find() } returns counter
+        every { counterRepository.save(any()) } just Runs
+        every { processedOperationRepository.save(operationId) } just Runs
+
+        // When
+        underTest.incrementCounter(subscriptionId, operationId)
+
+        // Then
+        verify(exactly = 1) { processedOperationRepository.existsById(operationId) }
+        verify(exactly = 1) { counterRepository.find() }
+        verify(exactly = 1) { counterRepository.save(SubscriptionCounter(count = 6)) }
+        verify(exactly = 1) { processedOperationRepository.save(operationId) }
+        confirmVerified(counterRepository, processedOperationRepository)
+    }
+
+    @Test
+    fun `should skip incrementing counter when operation is already processed`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val operationId = OperationId("${subscriptionId.value}-Activity_RegistrationCompleted")
+
+        every { processedOperationRepository.existsById(operationId) } returns true
+
+        // When
+        underTest.incrementCounter(subscriptionId, operationId)
+
+        // Then
+        verify(exactly = 1) { processedOperationRepository.existsById(operationId) }
+        verify(exactly = 0) { counterRepository.find() }
+        verify(exactly = 0) { counterRepository.save(any()) }
+        verify(exactly = 0) { processedOperationRepository.save(any()) }
+        confirmVerified(counterRepository, processedOperationRepository)
+    }
+}

--- a/examples/outbox-pattern/src/test/kotlin/io/miragon/example/adapter/out/zeebe/ProcessEngineOutboxSchedulerTest.kt
+++ b/examples/outbox-pattern/src/test/kotlin/io/miragon/example/adapter/out/zeebe/ProcessEngineOutboxSchedulerTest.kt
@@ -1,0 +1,101 @@
+package io.miragon.example.adapter.out.zeebe
+
+import io.miragon.example.adapter.out.db.message.MessageStatus
+import io.miragon.example.adapter.out.db.message.ProcessMessageEntity
+import io.miragon.example.adapter.out.db.message.ProcessMessageJpaRepository
+import io.camunda.client.CamundaClient
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.support.AbstractPlatformTransactionManager
+import org.springframework.transaction.support.DefaultTransactionStatus
+
+class ProcessEngineOutboxSchedulerTest {
+
+    private val camundaClient = mockk<CamundaClient>(relaxed = true)
+    private val repository = mockk<ProcessMessageJpaRepository>()
+    private val underTest = ProcessEngineOutboxScheduler(camundaClient, txManager, repository)
+
+    @Test
+    fun `should do nothing when no pending messages exist`() {
+        // Given
+        every { repository.findFirstByStatusWithLock(MessageStatus.PENDING) } returns null
+
+        // When
+        underTest.sendMessages()
+
+        // Then
+        verify(exactly = 1) { repository.findFirstByStatusWithLock(MessageStatus.PENDING) }
+        verify(exactly = 0) { camundaClient.newPublishMessageCommand() }
+        confirmVerified(repository)
+    }
+
+    @Test
+    fun `should send pending message to zeebe and mark it as sent`() {
+        // Given
+        val message = ProcessMessageEntity(
+            messageName = "form-submitted",
+            correlationId = "sub-123",
+            variables = """{"subscriptionId":"sub-123"}"""
+        )
+        val sentMessage = message.copy(status = MessageStatus.SENT)
+
+        every { repository.findFirstByStatusWithLock(MessageStatus.PENDING) } returnsMany listOf(message, null)
+        every { repository.save(sentMessage) } returns sentMessage
+        every {
+            camundaClient.newPublishMessageCommand()
+                .messageName(any())
+                .correlationKey(any())
+                .messageId(any())
+                .variables(any<Map<String, Any>>())
+                .timeToLive(any())
+                .send()
+                .join()
+        } returns mockk()
+
+        // When
+        underTest.sendMessages()
+
+        // Then
+        verify(exactly = 1) { repository.save(sentMessage) }
+    }
+
+    @Test
+    fun `should increment retry count when zeebe send fails`() {
+        // Given
+        val message = ProcessMessageEntity(
+            messageName = "form-submitted",
+            correlationId = "sub-456",
+            variables = """{"subscriptionId":"sub-456"}""",
+            retryCount = 0
+        )
+        val retryMessage = message.copy(retryCount = 1)
+
+        every { repository.findFirstByStatusWithLock(MessageStatus.PENDING) } returnsMany listOf(message, null)
+        every { repository.save(retryMessage) } returns retryMessage
+        every {
+            camundaClient.newPublishMessageCommand()
+                .messageName(any())
+                .correlationKey(any())
+                .messageId(any())
+                .variables(any<Map<String, Any>>())
+                .timeToLive(any())
+                .send()
+                .join()
+        } throws RuntimeException("Zeebe unavailable")
+
+        // When
+        underTest.sendMessages()
+
+        // Then
+        verify(exactly = 1) { repository.save(retryMessage) }
+    }
+
+    companion object {
+        private val txManager = object : AbstractPlatformTransactionManager() {
+            override fun doGetTransaction() = Any()
+            override fun doBegin(transaction: Any, definition: org.springframework.transaction.TransactionDefinition) {}
+            override fun doCommit(status: DefaultTransactionStatus) {}
+            override fun doRollback(status: DefaultTransactionStatus) {}
+        }
+    }
+}

--- a/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
+++ b/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
@@ -1,0 +1,39 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class AbortSubscriptionServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val underTest = AbortSubscriptionService(repository)
+
+    @Test
+    fun `should abort subscription registration`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+        every { repository.save(any<NewsletterSubscription>()) } returns mockk()
+
+        // When
+        underTest.abort(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        verify(exactly = 1) { repository.save(any()) }
+        confirmVerified(repository)
+    }
+}

--- a/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/ConfirmSubscriptionServiceTest.kt
+++ b/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/ConfirmSubscriptionServiceTest.kt
@@ -1,0 +1,43 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class ConfirmSubscriptionServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val processPort = mockk<NewsletterSubscriptionProcess>()
+    private val underTest = ConfirmSubscriptionService(repository, processPort)
+
+    @Test
+    fun `should confirm subscription and notify process`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+        every { repository.save(any<NewsletterSubscription>()) } returns mockk()
+        every { processPort.confirmSubscription(subscriptionId) } just Runs
+
+        // When
+        underTest.confirm(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { processPort.confirmSubscription(subscriptionId) }
+        confirmVerified(repository, processPort)
+    }
+}

--- a/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
+++ b/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class SendConfirmationMailServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val underTest = SendConfirmationMailService(repository)
+
+    @Test
+    fun `should find subscription and send confirmation mail`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+
+        // When
+        underTest.sendConfirmationMail(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        confirmVerified(repository)
+    }
+}

--- a/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
+++ b/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.util.*
+
+class SendWelcomeMailServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val underTest = SendWelcomeMailService(repository)
+
+    @Test
+    fun `should find subscription and send welcome mail`() {
+        // Given
+        val subscriptionId = SubscriptionId(UUID.randomUUID())
+        val subscription = NewsletterSubscription(
+            id = subscriptionId,
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletter = NewsletterId(UUID.randomUUID()),
+            registrationDate = LocalDateTime.now(),
+            status = SubscriptionStatus.PENDING
+        )
+
+        every { repository.find(subscriptionId) } returns subscription
+
+        // When
+        underTest.sendWelcomeMail(subscriptionId)
+
+        // Then
+        verify(exactly = 1) { repository.find(subscriptionId) }
+        confirmVerified(repository)
+    }
+}

--- a/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/SubscribeToNewsletterServiceTest.kt
+++ b/examples/outbox-pattern/src/test/kotlin/io/miragon/example/application/service/SubscribeToNewsletterServiceTest.kt
@@ -1,0 +1,37 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.`in`.SubscribeToNewsletterUseCase
+import io.miragon.example.application.port.out.NewsletterSubscriptionProcess
+import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
+import io.miragon.example.domain.*
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class SubscribeToNewsletterServiceTest {
+
+    private val repository = mockk<NewsletterSubscriptionRepository>()
+    private val processPort = mockk<NewsletterSubscriptionProcess>()
+    private val underTest = SubscribeToNewsletterService(repository, processPort)
+
+    @Test
+    fun `should create subscription and notify process when subscribing to newsletter`() {
+        // Given
+        val command = SubscribeToNewsletterUseCase.Command(
+            email = Email("test@example.com"),
+            name = Name("Test User"),
+            newsletterId = NewsletterId(UUID.randomUUID())
+        )
+
+        every { repository.save(any<NewsletterSubscription>()) } returns mockk()
+        every { processPort.submitForm(any()) } just Runs
+
+        // When
+        val subscriptionId = underTest.subscribe(command)
+
+        // Then
+        verify(exactly = 1) { repository.save(any()) }
+        verify(exactly = 1) { processPort.submitForm(subscriptionId) }
+        confirmVerified(repository, processPort)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds unit tests for all service classes in `after-transaction` and `outbox-pattern` (5 each)
- Adds missing tests for `IncrementSubscriptionCounterService` and `RegistrationCompletedWorker` in `idempotency-pattern`
- Follows the existing MockK pattern already established in the codebase

Closes #42