### PR TITLE
refactor(idempotency): centralize idempotency check in reusable executor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,8 @@ application/
 domain/            - Domain entities and value objects
 ```
 
-**Key point**: Use `@Transactional` at service layer. Idempotency checks happen there too.
+**Key point**: Use `@Transactional` at service layer. Idempotency is handled there too, via a central
+`IdempotentOperationExecutor` that services wrap their business logic in.
 
 ### Pattern Implementations
 
@@ -155,7 +156,8 @@ Saves messages to DB table in same transaction. Background scheduler sends them 
 
 #### Idempotency Pattern (`examples/idempotency-pattern`)
 
-Services check `processed_operations` table before executing. Uses composite key: `subscriptionId-elementId`.
+Services wrap their business logic in a central `IdempotentOperationExecutor` (`runOnce`), which checks the
+`processed_operations` table before executing. Uses composite key: `subscriptionId-elementId`.
 **Pattern**: Check if processed → Execute → Record completion (all in one transaction).
 
 #### Combined Pattern (`examples/combined-pattern`)
@@ -192,8 +194,8 @@ The BPMN model (`configuration/newsletter.bpmn`) is shared across both examples 
 
 ### Testing
 
-There are currently no automated tests in this repository. When implementing features, focus on manual testing via the
-Bruno API files and monitoring in Operate.
+The example modules have unit tests for their application services (`gradle test`). For end-to-end behavior,
+test manually via the Bruno API files and monitoring in Operate.
 
 ### Distributed Transaction Challenges
 

--- a/examples/combined-pattern/README.md
+++ b/examples/combined-pattern/README.md
@@ -38,8 +38,9 @@ together:
    `ProcessEngineOutboxScheduler` polls every 200ms, sends messages to Zeebe with a unique `messageId`, and marks
    them `SENT` (or increments `retryCount` on failure).
 2. **Inbound (Idempotency)** — every job worker builds a composite `OperationId` (`subscriptionId-elementId`) and
-   the services apply the **Check → Execute → Record** pattern against the `processed_operations` table, all inside
-   one `@Transactional` boundary.
+   the services wrap their business logic in a central `IdempotentOperationExecutor` that applies the
+   **Check → Execute → Record** pattern against the `processed_operations` table, all inside one
+   `@Transactional` boundary.
 
 Because both the business data **and** the outbox message are persisted in the same transaction, they commit
 atomically — the engine is never notified about data that was rolled back.
@@ -86,7 +87,8 @@ private fun sendMessage(message: ProcessMessageEntity) {
 
 ### **Inbound: Idempotent Workers**
 
-Workers construct the composite `OperationId`; the service checks it before doing any work:
+Workers construct the composite `OperationId`; the service wraps its business logic in the central
+`IdempotentOperationExecutor`, which performs the **Check → Execute → Record** cycle in one place:
 
 ```kotlin
 @JobWorker(type = ServiceTasks.NEWSLETTER_SEND_WELCOME_MAIL)
@@ -99,21 +101,37 @@ fun sendWelcomeMail(job: ActivatedJob, @Variable("subscriptionId") subscriptionI
 ```
 
 ```kotlin
+@Component
+class IdempotentOperationExecutor(
+    private val processedOperationRepository: ProcessedOperationRepository
+) {
+    fun runOnce(operationId: OperationId, block: () -> Unit) {
+        if (processedOperationRepository.existsById(operationId)) return // already done -> skip
+        block()                                                          // execute
+        processedOperationRepository.save(operationId)                   // record
+    }
+}
+```
+
+```kotlin
 @Service
 @Transactional
 class SendWelcomeMailService(
     private val repository: NewsletterSubscriptionRepository,
-    private val processedOperationRepository: ProcessedOperationRepository,
+    private val idempotencyGuard: IdempotentOperationExecutor,
 ) : SendWelcomeMailUseCase {
 
     override fun sendWelcomeMail(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) return // already done -> skip
-        val subscription = repository.find(subscriptionId)
-        log.info { "Sending welcome mail to ${subscription.email}" }      // execute
-        processedOperationRepository.save(operationId)                    // record
+        idempotencyGuard.runOnce(operationId) {
+            val subscription = repository.find(subscriptionId)
+            log.info { "Sending welcome mail to ${subscription.email}" }
+        }
     }
 }
 ```
+
+Because `runOnce` is called inside the service's `@Transactional` boundary, check, business logic and record
+still commit atomically.
 
 ## **Sequence Flow** 📊
 

--- a/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/AbortSubscriptionService.kt
+++ b/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/AbortSubscriptionService.kt
@@ -2,7 +2,6 @@ package io.miragon.example.application.service
 
 import io.miragon.example.application.port.`in`.AbortSubscriptionUseCase
 import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
-import io.miragon.example.application.port.out.ProcessedOperationRepository
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
 import jakarta.transaction.Transactional
@@ -13,22 +12,17 @@ import org.springframework.stereotype.Service
 @Transactional
 class AbortSubscriptionService(
     private val repository: NewsletterSubscriptionRepository,
-    private val processedOperationRepository: ProcessedOperationRepository
+    private val idempotencyGuard: IdempotentOperationExecutor
 ) : AbortSubscriptionUseCase {
 
     private val log = KotlinLogging.logger {}
 
     override fun abort(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) {
-            log.info { "Skipping already processed operation: ${operationId.value}" }
-            return
+        idempotencyGuard.runOnce(operationId) {
+            val subscription = repository.find(subscriptionId)
+            subscription.abortRegistration()
+            repository.save(subscription)
+            log.info { "Aborted subscription-registration ${subscription.id}" }
         }
-
-        val subscription = repository.find(subscriptionId)
-        subscription.abortRegistration()
-        repository.save(subscription)
-        log.info { "Aborted subscription-registration ${subscription.id}" }
-
-        processedOperationRepository.save(operationId)
     }
 }

--- a/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/IdempotentOperationExecutor.kt
+++ b/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/IdempotentOperationExecutor.kt
@@ -1,0 +1,30 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.ProcessedOperationRepository
+import io.miragon.example.domain.OperationId
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+
+/**
+ * Centralizes the idempotency check: skips the block if the operation
+ * was already processed, otherwise executes it and records its completion.
+ * Must be called inside the caller's transaction so that check,
+ * business logic and record stay atomic.
+ */
+@Component
+class IdempotentOperationExecutor(
+    private val processedOperationRepository: ProcessedOperationRepository
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    fun runOnce(operationId: OperationId, block: () -> Unit) {
+        if (processedOperationRepository.existsById(operationId)) {
+            log.info { "Skipping already processed operation: ${operationId.value}" }
+            return
+        }
+
+        block()
+        processedOperationRepository.save(operationId)
+    }
+}

--- a/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterService.kt
+++ b/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterService.kt
@@ -1,7 +1,6 @@
 package io.miragon.example.application.service
 
 import io.miragon.example.application.port.`in`.IncrementSubscriptionCounterUseCase
-import io.miragon.example.application.port.out.ProcessedOperationRepository
 import io.miragon.example.application.port.out.SubscriptionCounterRepository
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
@@ -13,22 +12,17 @@ import org.springframework.stereotype.Service
 @Transactional
 class IncrementSubscriptionCounterService(
     private val counterRepository: SubscriptionCounterRepository,
-    private val processedOperationRepository: ProcessedOperationRepository
+    private val idempotencyGuard: IdempotentOperationExecutor
 ) : IncrementSubscriptionCounterUseCase {
 
     private val log = KotlinLogging.logger {}
 
     override fun incrementCounter(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) {
-            log.info { "Skipping already processed operation: ${operationId.value}" }
-            return
+        idempotencyGuard.runOnce(operationId) {
+            val counter = counterRepository.find()
+            val updatedCounter = counter.increment()
+            counterRepository.save(updatedCounter)
+            log.info { "Incremented subscription counter for ${subscriptionId.value}: ${updatedCounter.count}" }
         }
-
-        val counter = counterRepository.find()
-        val updatedCounter = counter.increment()
-        counterRepository.save(updatedCounter)
-        log.info { "Incremented subscription counter for ${subscriptionId.value}: ${updatedCounter.count}" }
-
-        processedOperationRepository.save(operationId)
     }
 }

--- a/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/SendConfirmationMailService.kt
+++ b/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/SendConfirmationMailService.kt
@@ -2,7 +2,6 @@ package io.miragon.example.application.service
 
 import io.miragon.example.application.port.`in`.SendConfirmationMailUseCase
 import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
-import io.miragon.example.application.port.out.ProcessedOperationRepository
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
 import jakarta.transaction.Transactional
@@ -13,20 +12,15 @@ import org.springframework.stereotype.Service
 @Transactional
 class SendConfirmationMailService(
     private val repository: NewsletterSubscriptionRepository,
-    private val processedOperationRepository: ProcessedOperationRepository
+    private val idempotencyGuard: IdempotentOperationExecutor
 ) : SendConfirmationMailUseCase {
 
     private val log = KotlinLogging.logger {}
 
     override fun sendConfirmationMail(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) {
-            log.info { "Skipping already processed operation: ${operationId.value}" }
-            return
+        idempotencyGuard.runOnce(operationId) {
+            val subscription = repository.find(subscriptionId)
+            log.info { "Sending confirmation mail to ${subscription.email}" }
         }
-
-        val subscription = repository.find(subscriptionId)
-        log.info { "Sending confirmation mail to ${subscription.email}" }
-
-        processedOperationRepository.save(operationId)
     }
 }

--- a/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/SendWelcomeMailService.kt
+++ b/examples/combined-pattern/src/main/kotlin/io/miragon/example/application/service/SendWelcomeMailService.kt
@@ -2,7 +2,6 @@ package io.miragon.example.application.service
 
 import io.miragon.example.application.port.`in`.SendWelcomeMailUseCase
 import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
-import io.miragon.example.application.port.out.ProcessedOperationRepository
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
 import jakarta.transaction.Transactional
@@ -13,20 +12,15 @@ import org.springframework.stereotype.Service
 @Transactional
 class SendWelcomeMailService(
     private val repository: NewsletterSubscriptionRepository,
-    private val processedOperationRepository: ProcessedOperationRepository
+    private val idempotencyGuard: IdempotentOperationExecutor
 ) : SendWelcomeMailUseCase {
 
     private val log = KotlinLogging.logger {}
 
     override fun sendWelcomeMail(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) {
-            log.info { "Skipping already processed operation: ${operationId.value}" }
-            return
+        idempotencyGuard.runOnce(operationId) {
+            val subscription = repository.find(subscriptionId)
+            log.info { "Sending welcome mail to ${subscription.email}" }
         }
-
-        val subscription = repository.find(subscriptionId)
-        log.info { "Sending welcome mail to ${subscription.email}" }
-
-        processedOperationRepository.save(operationId)
     }
 }

--- a/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
+++ b/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
@@ -16,7 +16,7 @@ class AbortSubscriptionServiceTest {
 
     private val repository = mockk<NewsletterSubscriptionRepository>()
     private val processedOperationRepository = mockk<ProcessedOperationRepository>()
-    private val underTest = AbortSubscriptionService(repository, processedOperationRepository)
+    private val underTest = AbortSubscriptionService(repository, IdempotentOperationExecutor(processedOperationRepository))
 
     @Test
     fun `should abort subscription when operation is not processed yet`() {

--- a/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/IdempotentOperationExecutorTest.kt
+++ b/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/IdempotentOperationExecutorTest.kt
@@ -1,0 +1,55 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.ProcessedOperationRepository
+import io.miragon.example.domain.OperationId
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+/**
+ * Unit test for IdempotentOperationExecutor.
+ * Tests the central Check → Execute → Record cycle.
+ */
+class IdempotentOperationExecutorTest {
+
+    private val processedOperationRepository = mockk<ProcessedOperationRepository>()
+    private val underTest = IdempotentOperationExecutor(processedOperationRepository)
+
+    @Test
+    fun `should execute block and record operation when not processed yet`() {
+        // Given
+        val operationId = OperationId("${UUID.randomUUID()}-Activity_SendWelcomeMail")
+        val block = mockk<() -> Unit>()
+
+        every { processedOperationRepository.existsById(operationId) } returns false
+        every { block.invoke() } just Runs
+        every { processedOperationRepository.save(operationId) } just Runs
+
+        // When
+        underTest.runOnce(operationId, block)
+
+        // Then
+        verify(exactly = 1) { processedOperationRepository.existsById(operationId) }
+        verify(exactly = 1) { block.invoke() }
+        verify(exactly = 1) { processedOperationRepository.save(operationId) }
+        confirmVerified(processedOperationRepository, block)
+    }
+
+    @Test
+    fun `should skip block when operation is already processed`() {
+        // Given
+        val operationId = OperationId("${UUID.randomUUID()}-Activity_SendWelcomeMail")
+        val block = mockk<() -> Unit>()
+
+        every { processedOperationRepository.existsById(operationId) } returns true
+
+        // When
+        underTest.runOnce(operationId, block)
+
+        // Then
+        verify(exactly = 1) { processedOperationRepository.existsById(operationId) }
+        verify(exactly = 0) { block.invoke() }
+        verify(exactly = 0) { processedOperationRepository.save(any()) }
+        confirmVerified(processedOperationRepository, block)
+    }
+}

--- a/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterServiceTest.kt
+++ b/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterServiceTest.kt
@@ -13,7 +13,7 @@ class IncrementSubscriptionCounterServiceTest {
 
     private val counterRepository = mockk<SubscriptionCounterRepository>()
     private val processedOperationRepository = mockk<ProcessedOperationRepository>()
-    private val underTest = IncrementSubscriptionCounterService(counterRepository, processedOperationRepository)
+    private val underTest = IncrementSubscriptionCounterService(counterRepository, IdempotentOperationExecutor(processedOperationRepository))
 
     @Test
     fun `should increment counter when operation is not processed yet`() {

--- a/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
+++ b/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
@@ -16,7 +16,7 @@ class SendConfirmationMailServiceTest {
 
     private val repository = mockk<NewsletterSubscriptionRepository>()
     private val processedOperationRepository = mockk<ProcessedOperationRepository>()
-    private val underTest = SendConfirmationMailService(repository, processedOperationRepository)
+    private val underTest = SendConfirmationMailService(repository, IdempotentOperationExecutor(processedOperationRepository))
 
     @Test
     fun `should send confirmation mail when operation is not processed yet`() {

--- a/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
+++ b/examples/combined-pattern/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
@@ -16,7 +16,7 @@ class SendWelcomeMailServiceTest {
 
     private val repository = mockk<NewsletterSubscriptionRepository>()
     private val processedOperationRepository = mockk<ProcessedOperationRepository>()
-    private val underTest = SendWelcomeMailService(repository, processedOperationRepository)
+    private val underTest = SendWelcomeMailService(repository, IdempotentOperationExecutor(processedOperationRepository))
 
     @Test
     fun `should send welcome mail when operation is not processed yet`() {

--- a/examples/idempotency-pattern/README.md
+++ b/examples/idempotency-pattern/README.md
@@ -10,12 +10,13 @@ The idempotency pattern consists of three main components:
 
 1. **OperationId Value Object**: A composite key combining `subscriptionId-elementId` for business-driven idempotency tracking
 2. **ProcessedOperations Table**: Database table that records completed operations with their operationId and timestamp
-3. **Service Layer Check**: Services verify if an operation has been processed before executing business logic
+3. **IdempotentOperationExecutor**: A central component that performs the Check → Execute → Record cycle; services wrap their business logic in it
 
 **Key Features:**
 
 - **Composite OperationId**: Uses `subscriptionId-elementId` instead of internal job keys for meaningful tracking
-- **Service-Layer Implementation**: Idempotency logic lives in services, not workers (clean separation of concerns)
+- **Centralized Check**: The Check → Execute → Record logic lives in one reusable executor, not in every service
+- **Service-Layer Implementation**: Idempotency logic lives in the application layer, not in workers (clean separation of concerns)
 - **Atomic Pattern**: Check → Execute → Record happens in single `@Transactional` boundary
 - **Minimal Infrastructure**: Just a simple database table, no schedulers or background processes needed
 
@@ -50,40 +51,60 @@ data class ProcessedOperationEntity(
 )
 ```
 
-### **Service Layer Implementation**
+### **The IdempotentOperationExecutor**
 
-Services implement the Check → Execute → Record pattern:
+The Check → Execute → Record pattern is implemented once, in a reusable executor:
 
 ```kotlin
-@Service
-@Transactional
-class SendConfirmationMailService(
-    private val repository: NewsletterSubscriptionRepository,
+@Component
+class IdempotentOperationExecutor(
     private val processedOperationRepository: ProcessedOperationRepository
-) : SendConfirmationMailUseCase {
+) {
 
     private val log = KotlinLogging.logger {}
 
-    override fun sendConfirmationMail(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId.value)) {
+    fun runOnce(operationId: OperationId, block: () -> Unit) {
+        if (processedOperationRepository.existsById(operationId)) {
             log.info { "Skipping already processed operation: ${operationId.value}" }
             return
         }
 
-        val subscription = repository.find(subscriptionId)
-        log.info { "Sending confirmation mail to ${subscription.email}" }
-
-        processedOperationRepository.save(operationId.value)
+        block()
+        processedOperationRepository.save(operationId)
     }
 }
 ```
 
 **Pattern Breakdown:**
 1. **Check**: Query `processed_operations` table for the operationId
-2. **Execute**: If not found, run the business logic (send email)
+2. **Execute**: If not found, run the business logic (the `block`)
 3. **Record**: Save the operationId to mark completion
 
-All three steps happen atomically within the `@Transactional` boundary, preventing race conditions.
+The executor must be called **inside** the caller's transaction: because it runs within the
+service's `@Transactional` boundary, all three steps stay atomic, preventing race conditions.
+
+### **Service Layer Implementation**
+
+Services wrap their business logic in `runOnce` and stay focused on business behavior:
+
+```kotlin
+@Service
+@Transactional
+class SendConfirmationMailService(
+    private val repository: NewsletterSubscriptionRepository,
+    private val idempotencyGuard: IdempotentOperationExecutor
+) : SendConfirmationMailUseCase {
+
+    private val log = KotlinLogging.logger {}
+
+    override fun sendConfirmationMail(subscriptionId: SubscriptionId, operationId: OperationId) {
+        idempotencyGuard.runOnce(operationId) {
+            val subscription = repository.find(subscriptionId)
+            log.info { "Sending confirmation mail to ${subscription.email}" }
+        }
+    }
+}
+```
 
 ### **Worker Layer**
 
@@ -126,20 +147,15 @@ This example also includes a subscription counter that demonstrates how the idem
 @Transactional
 class IncrementSubscriptionCounterService(
     private val counterRepository: SubscriptionCounterRepository,
-    private val processedOperationRepository: ProcessedOperationRepository
+    private val idempotencyGuard: IdempotentOperationExecutor
 ) : IncrementSubscriptionCounterUseCase {
 
     override fun incrementCounter(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) {
-            log.info { "Skipping already processed operation: ${operationId.value}" }
-            return  // Early exit - operation already completed
+        idempotencyGuard.runOnce(operationId) {
+            val counter = counterRepository.find()
+            val updatedCounter = counter.increment()
+            counterRepository.save(updatedCounter)
         }
-
-        val counter = counterRepository.find()
-        val updatedCounter = counter.increment()
-        counterRepository.save(updatedCounter)
-
-        processedOperationRepository.save(operationId)  // Mark as completed
     }
 }
 ```
@@ -148,7 +164,7 @@ class IncrementSubscriptionCounterService(
 
 1. Worker listens to `newsletter.registrationCompleted` message end event
 2. Constructs `OperationId` from `subscriptionId-elementId`
-3. Service checks if this exact operation was already processed
+3. The executor checks if this exact operation was already processed
 4. If already processed: Skip increment (idempotent behavior)
 5. If not processed: Increment counter AND record operation (atomic)
 
@@ -197,7 +213,7 @@ sequenceDiagram
 
 - **Prevents Duplicate Processing**: Handles Zeebe's at-least-once delivery safely
 - **Business-Driven Keys**: OperationId based on domain entities + BPMN elements, not internal job IDs
-- **Clean Architecture**: Idempotency logic in services, workers stay thin
+- **Clean Architecture**: Idempotency logic in one central executor, services and workers stay thin
 - **Atomic Pattern**: Check-execute-record happens in single transaction (no race conditions)
 - **Simple Infrastructure**: Just a database table, no schedulers or message queues
 - **Audit Trail**: `processed_at` timestamp provides history of when operations completed

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/AbortSubscriptionService.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/AbortSubscriptionService.kt
@@ -2,7 +2,6 @@ package io.miragon.example.application.service
 
 import io.miragon.example.application.port.`in`.AbortSubscriptionUseCase
 import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
-import io.miragon.example.application.port.out.ProcessedOperationRepository
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
 import jakarta.transaction.Transactional
@@ -13,22 +12,17 @@ import org.springframework.stereotype.Service
 @Transactional
 class AbortSubscriptionService(
     private val repository: NewsletterSubscriptionRepository,
-    private val processedOperationRepository: ProcessedOperationRepository
+    private val idempotencyGuard: IdempotentOperationExecutor
 ) : AbortSubscriptionUseCase {
 
     private val log = KotlinLogging.logger {}
 
     override fun abort(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) {
-            log.info { "Skipping already processed operation: ${operationId.value}" }
-            return
+        idempotencyGuard.runOnce(operationId) {
+            val subscription = repository.find(subscriptionId)
+            subscription.abortRegistration()
+            repository.save(subscription)
+            log.info { "Aborted subscription-registration ${subscription.id}" }
         }
-
-        val subscription = repository.find(subscriptionId)
-        subscription.abortRegistration()
-        repository.save(subscription)
-        log.info { "Aborted subscription-registration ${subscription.id}" }
-
-        processedOperationRepository.save(operationId)
     }
 }

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/IdempotentOperationExecutor.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/IdempotentOperationExecutor.kt
@@ -1,0 +1,30 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.ProcessedOperationRepository
+import io.miragon.example.domain.OperationId
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+
+/**
+ * Centralizes the idempotency check: skips the block if the operation
+ * was already processed, otherwise executes it and records its completion.
+ * Must be called inside the caller's transaction so that check,
+ * business logic and record stay atomic.
+ */
+@Component
+class IdempotentOperationExecutor(
+    private val processedOperationRepository: ProcessedOperationRepository
+) {
+
+    private val log = KotlinLogging.logger {}
+
+    fun runOnce(operationId: OperationId, block: () -> Unit) {
+        if (processedOperationRepository.existsById(operationId)) {
+            log.info { "Skipping already processed operation: ${operationId.value}" }
+            return
+        }
+
+        block()
+        processedOperationRepository.save(operationId)
+    }
+}

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterService.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterService.kt
@@ -1,7 +1,6 @@
 package io.miragon.example.application.service
 
 import io.miragon.example.application.port.`in`.IncrementSubscriptionCounterUseCase
-import io.miragon.example.application.port.out.ProcessedOperationRepository
 import io.miragon.example.application.port.out.SubscriptionCounterRepository
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
@@ -13,22 +12,17 @@ import org.springframework.stereotype.Service
 @Transactional
 class IncrementSubscriptionCounterService(
     private val counterRepository: SubscriptionCounterRepository,
-    private val processedOperationRepository: ProcessedOperationRepository
+    private val idempotencyGuard: IdempotentOperationExecutor
 ) : IncrementSubscriptionCounterUseCase {
 
     private val log = KotlinLogging.logger {}
 
     override fun incrementCounter(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) {
-            log.info { "Skipping already processed operation: ${operationId.value}" }
-            return
+        idempotencyGuard.runOnce(operationId) {
+            val counter = counterRepository.find()
+            val updatedCounter = counter.increment()
+            counterRepository.save(updatedCounter)
+            log.info { "Incremented subscription counter for ${subscriptionId.value}: ${updatedCounter.count}" }
         }
-
-        val counter = counterRepository.find()
-        val updatedCounter = counter.increment()
-        counterRepository.save(updatedCounter)
-        log.info { "Incremented subscription counter for ${subscriptionId.value}: ${updatedCounter.count}" }
-
-        processedOperationRepository.save(operationId)
     }
 }

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/SendConfirmationMailService.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/SendConfirmationMailService.kt
@@ -2,7 +2,6 @@ package io.miragon.example.application.service
 
 import io.miragon.example.application.port.`in`.SendConfirmationMailUseCase
 import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
-import io.miragon.example.application.port.out.ProcessedOperationRepository
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
 import jakarta.transaction.Transactional
@@ -13,20 +12,15 @@ import org.springframework.stereotype.Service
 @Transactional
 class SendConfirmationMailService(
     private val repository: NewsletterSubscriptionRepository,
-    private val processedOperationRepository: ProcessedOperationRepository
+    private val idempotencyGuard: IdempotentOperationExecutor
 ) : SendConfirmationMailUseCase {
 
     private val log = KotlinLogging.logger {}
 
     override fun sendConfirmationMail(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) {
-            log.info { "Skipping already processed operation: ${operationId.value}" }
-            return
+        idempotencyGuard.runOnce(operationId) {
+            val subscription = repository.find(subscriptionId)
+            log.info { "Sending confirmation mail to ${subscription.email}" }
         }
-
-        val subscription = repository.find(subscriptionId)
-        log.info { "Sending confirmation mail to ${subscription.email}" }
-
-        processedOperationRepository.save(operationId)
     }
 }

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/SendWelcomeMailService.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/application/service/SendWelcomeMailService.kt
@@ -2,7 +2,6 @@ package io.miragon.example.application.service
 
 import io.miragon.example.application.port.`in`.SendWelcomeMailUseCase
 import io.miragon.example.application.port.out.NewsletterSubscriptionRepository
-import io.miragon.example.application.port.out.ProcessedOperationRepository
 import io.miragon.example.domain.OperationId
 import io.miragon.example.domain.SubscriptionId
 import jakarta.transaction.Transactional
@@ -13,20 +12,15 @@ import org.springframework.stereotype.Service
 @Transactional
 class SendWelcomeMailService(
     private val repository: NewsletterSubscriptionRepository,
-    private val processedOperationRepository: ProcessedOperationRepository
+    private val idempotencyGuard: IdempotentOperationExecutor
 ) : SendWelcomeMailUseCase {
 
     private val log = KotlinLogging.logger {}
 
     override fun sendWelcomeMail(subscriptionId: SubscriptionId, operationId: OperationId) {
-        if (processedOperationRepository.existsById(operationId)) {
-            log.info { "Skipping already processed operation: ${operationId.value}" }
-            return
+        idempotencyGuard.runOnce(operationId) {
+            val subscription = repository.find(subscriptionId)
+            log.info { "Sending welcome mail to ${subscription.email}" }
         }
-
-        val subscription = repository.find(subscriptionId)
-        log.info { "Sending welcome mail to ${subscription.email}" }
-
-        processedOperationRepository.save(operationId)
     }
 }

--- a/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
+++ b/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/AbortSubscriptionServiceTest.kt
@@ -16,7 +16,7 @@ class AbortSubscriptionServiceTest {
 
     private val repository = mockk<NewsletterSubscriptionRepository>()
     private val processedOperationRepository = mockk<ProcessedOperationRepository>()
-    private val underTest = AbortSubscriptionService(repository, processedOperationRepository)
+    private val underTest = AbortSubscriptionService(repository, IdempotentOperationExecutor(processedOperationRepository))
 
     @Test
     fun `should abort subscription when operation is not processed yet`() {

--- a/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/IdempotentOperationExecutorTest.kt
+++ b/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/IdempotentOperationExecutorTest.kt
@@ -1,0 +1,55 @@
+package io.miragon.example.application.service
+
+import io.miragon.example.application.port.out.ProcessedOperationRepository
+import io.miragon.example.domain.OperationId
+import io.mockk.*
+import org.junit.jupiter.api.Test
+import java.util.*
+
+/**
+ * Unit test for IdempotentOperationExecutor.
+ * Tests the central Check → Execute → Record cycle.
+ */
+class IdempotentOperationExecutorTest {
+
+    private val processedOperationRepository = mockk<ProcessedOperationRepository>()
+    private val underTest = IdempotentOperationExecutor(processedOperationRepository)
+
+    @Test
+    fun `should execute block and record operation when not processed yet`() {
+        // Given
+        val operationId = OperationId("${UUID.randomUUID()}-Activity_SendWelcomeMail")
+        val block = mockk<() -> Unit>()
+
+        every { processedOperationRepository.existsById(operationId) } returns false
+        every { block.invoke() } just Runs
+        every { processedOperationRepository.save(operationId) } just Runs
+
+        // When
+        underTest.runOnce(operationId, block)
+
+        // Then
+        verify(exactly = 1) { processedOperationRepository.existsById(operationId) }
+        verify(exactly = 1) { block.invoke() }
+        verify(exactly = 1) { processedOperationRepository.save(operationId) }
+        confirmVerified(processedOperationRepository, block)
+    }
+
+    @Test
+    fun `should skip block when operation is already processed`() {
+        // Given
+        val operationId = OperationId("${UUID.randomUUID()}-Activity_SendWelcomeMail")
+        val block = mockk<() -> Unit>()
+
+        every { processedOperationRepository.existsById(operationId) } returns true
+
+        // When
+        underTest.runOnce(operationId, block)
+
+        // Then
+        verify(exactly = 1) { processedOperationRepository.existsById(operationId) }
+        verify(exactly = 0) { block.invoke() }
+        verify(exactly = 0) { processedOperationRepository.save(any()) }
+        confirmVerified(processedOperationRepository, block)
+    }
+}

--- a/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterServiceTest.kt
+++ b/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/IncrementSubscriptionCounterServiceTest.kt
@@ -13,7 +13,7 @@ class IncrementSubscriptionCounterServiceTest {
 
     private val counterRepository = mockk<SubscriptionCounterRepository>()
     private val processedOperationRepository = mockk<ProcessedOperationRepository>()
-    private val underTest = IncrementSubscriptionCounterService(counterRepository, processedOperationRepository)
+    private val underTest = IncrementSubscriptionCounterService(counterRepository, IdempotentOperationExecutor(processedOperationRepository))
 
     @Test
     fun `should increment counter when operation is not processed yet`() {

--- a/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
+++ b/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/SendConfirmationMailServiceTest.kt
@@ -16,7 +16,7 @@ class SendConfirmationMailServiceTest {
 
     private val repository = mockk<NewsletterSubscriptionRepository>()
     private val processedOperationRepository = mockk<ProcessedOperationRepository>()
-    private val underTest = SendConfirmationMailService(repository, processedOperationRepository)
+    private val underTest = SendConfirmationMailService(repository, IdempotentOperationExecutor(processedOperationRepository))
 
     @Test
     fun `should send confirmation mail when operation is not processed yet`() {

--- a/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
+++ b/examples/idempotency-pattern/src/test/kotlin/io/miragon/example/application/service/SendWelcomeMailServiceTest.kt
@@ -16,7 +16,7 @@ class SendWelcomeMailServiceTest {
 
     private val repository = mockk<NewsletterSubscriptionRepository>()
     private val processedOperationRepository = mockk<ProcessedOperationRepository>()
-    private val underTest = SendWelcomeMailService(repository, processedOperationRepository)
+    private val underTest = SendWelcomeMailService(repository, IdempotentOperationExecutor(processedOperationRepository))
 
     @Test
     fun `should send welcome mail when operation is not processed yet`() {


### PR DESCRIPTION
## Summary

Resolves the duplicated idempotency boilerplate described in #71: the check -> execute -> record cycle was copied into every idempotent domain service. It now lives in a single reusable `IdempotentOperationExecutor` per module; services wrap their business logic in `runOnce(operationId) { ... }` and stay focused on business behavior.

## Changes

- New `IdempotentOperationExecutor` in `idempotency-pattern` and `combined-pattern` (application layer)
- 8 services slimmed down: inline exists-check and record removed, logic wrapped in `runOnce`
- Behavior unchanged: executor runs inside the service's `@Transactional` boundary, so check + logic + record stay atomic; log output identical
- Existing service tests adapted (real executor around mocked repository), new unit tests for the executor
- READMEs of both modules and CLAUDE.md updated to describe the central executor

Non-breaking: no changes to ports, workers, database schema or BPMN.

Closes #71