### PR TITLE
build(deps): migrate bpmn-to-code to 3.0.0 (io.miragon)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Use Bruno API client with files in `bruno/` directory:
 
 ```bash
 # Generate Kotlin models from BPMN files
-gradle generateBpmnModels
+gradle generateBpmnModelApi
 
 # BPMN source: configuration/newsletter.bpmn
 # Generated output: examples/*/src/main/kotlin/io/miragon/example/adapter/process/

--- a/examples/after-transaction/build.gradle.kts
+++ b/examples/after-transaction/build.gradle.kts
@@ -1,6 +1,6 @@
-import io.github.emaarco.bpmn.adapter.GenerateBpmnModelsTask
-import io.github.emaarco.bpmn.domain.shared.OutputLanguage
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.adapter.GenerateBpmnModelsTask
+import io.miragon.bpmn.domain.shared.OutputLanguage
+import io.miragon.bpmn.domain.shared.ProcessEngine
 
 plugins {
     alias(libs.plugins.kotlinJvm)
@@ -33,7 +33,7 @@ sourceSets {
     }
 }
 
-tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
+tasks.named<GenerateBpmnModelsTask>("generateBpmnModelApi") {
     baseDir = "${projectDir}/../../configuration"
     filePattern = "newsletter.bpmn"
     outputFolderPath = "$projectDir/src/main/kotlin"
@@ -57,5 +57,5 @@ tasks.withType<Test> {
 }
 
 tasks.named("build") {
-    dependsOn("generateBpmnModels")
+    dependsOn("generateBpmnModelApi")
 }

--- a/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
+++ b/examples/after-transaction/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
@@ -3,14 +3,14 @@
 
 package io.miragon.example.adapter.process
 
-import io.github.emaarco.bpmn.runtime.BpmnEngine
-import io.github.emaarco.bpmn.runtime.BpmnFlow
-import io.github.emaarco.bpmn.runtime.BpmnRelations
-import io.github.emaarco.bpmn.runtime.BpmnTimer
-import io.github.emaarco.bpmn.runtime.ElementId
-import io.github.emaarco.bpmn.runtime.MessageName
-import io.github.emaarco.bpmn.runtime.ProcessId
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.BpmnEngine
+import io.miragon.bpmn.runtime.BpmnFlow
+import io.miragon.bpmn.runtime.BpmnRelations
+import io.miragon.bpmn.runtime.BpmnTimer
+import io.miragon.bpmn.runtime.ElementId
+import io.miragon.bpmn.runtime.MessageName
+import io.miragon.bpmn.runtime.ProcessId
+import io.miragon.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 

--- a/examples/base-scenario/build.gradle.kts
+++ b/examples/base-scenario/build.gradle.kts
@@ -1,6 +1,6 @@
-import io.github.emaarco.bpmn.adapter.GenerateBpmnModelsTask
-import io.github.emaarco.bpmn.domain.shared.OutputLanguage
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.adapter.GenerateBpmnModelsTask
+import io.miragon.bpmn.domain.shared.OutputLanguage
+import io.miragon.bpmn.domain.shared.ProcessEngine
 
 plugins {
     alias(libs.plugins.kotlinJvm)
@@ -33,7 +33,7 @@ sourceSets {
     }
 }
 
-tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
+tasks.named<GenerateBpmnModelsTask>("generateBpmnModelApi") {
     baseDir = "${projectDir}/../../configuration"
     filePattern = "newsletter.bpmn"
     outputFolderPath = "$projectDir/src/main/kotlin"
@@ -57,5 +57,5 @@ tasks.withType<Test> {
 }
 
 tasks.named("build") {
-    dependsOn("generateBpmnModels")
+    dependsOn("generateBpmnModelApi")
 }

--- a/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
+++ b/examples/base-scenario/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
@@ -3,14 +3,14 @@
 
 package io.miragon.example.adapter.process
 
-import io.github.emaarco.bpmn.runtime.BpmnEngine
-import io.github.emaarco.bpmn.runtime.BpmnFlow
-import io.github.emaarco.bpmn.runtime.BpmnRelations
-import io.github.emaarco.bpmn.runtime.BpmnTimer
-import io.github.emaarco.bpmn.runtime.ElementId
-import io.github.emaarco.bpmn.runtime.MessageName
-import io.github.emaarco.bpmn.runtime.ProcessId
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.BpmnEngine
+import io.miragon.bpmn.runtime.BpmnFlow
+import io.miragon.bpmn.runtime.BpmnRelations
+import io.miragon.bpmn.runtime.BpmnTimer
+import io.miragon.bpmn.runtime.ElementId
+import io.miragon.bpmn.runtime.MessageName
+import io.miragon.bpmn.runtime.ProcessId
+import io.miragon.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 

--- a/examples/combined-pattern/build.gradle.kts
+++ b/examples/combined-pattern/build.gradle.kts
@@ -1,6 +1,6 @@
-import io.github.emaarco.bpmn.adapter.GenerateBpmnModelsTask
-import io.github.emaarco.bpmn.domain.shared.OutputLanguage
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.adapter.GenerateBpmnModelsTask
+import io.miragon.bpmn.domain.shared.OutputLanguage
+import io.miragon.bpmn.domain.shared.ProcessEngine
 
 plugins {
     alias(libs.plugins.kotlinJvm)
@@ -33,7 +33,7 @@ sourceSets {
     }
 }
 
-tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
+tasks.named<GenerateBpmnModelsTask>("generateBpmnModelApi") {
     baseDir = "${projectDir}/../../configuration"
     filePattern = "newsletter.bpmn"
     outputFolderPath = "$projectDir/src/main/kotlin"
@@ -57,5 +57,5 @@ tasks.withType<Test> {
 }
 
 tasks.named("build") {
-    dependsOn("generateBpmnModels")
+    dependsOn("generateBpmnModelApi")
 }

--- a/examples/combined-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
+++ b/examples/combined-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
@@ -3,14 +3,14 @@
 
 package io.miragon.example.adapter.process
 
-import io.github.emaarco.bpmn.runtime.BpmnEngine
-import io.github.emaarco.bpmn.runtime.BpmnFlow
-import io.github.emaarco.bpmn.runtime.BpmnRelations
-import io.github.emaarco.bpmn.runtime.BpmnTimer
-import io.github.emaarco.bpmn.runtime.ElementId
-import io.github.emaarco.bpmn.runtime.MessageName
-import io.github.emaarco.bpmn.runtime.ProcessId
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.BpmnEngine
+import io.miragon.bpmn.runtime.BpmnFlow
+import io.miragon.bpmn.runtime.BpmnRelations
+import io.miragon.bpmn.runtime.BpmnTimer
+import io.miragon.bpmn.runtime.ElementId
+import io.miragon.bpmn.runtime.MessageName
+import io.miragon.bpmn.runtime.ProcessId
+import io.miragon.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 

--- a/examples/idempotency-pattern/build.gradle.kts
+++ b/examples/idempotency-pattern/build.gradle.kts
@@ -1,6 +1,6 @@
-import io.github.emaarco.bpmn.adapter.GenerateBpmnModelsTask
-import io.github.emaarco.bpmn.domain.shared.OutputLanguage
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.adapter.GenerateBpmnModelsTask
+import io.miragon.bpmn.domain.shared.OutputLanguage
+import io.miragon.bpmn.domain.shared.ProcessEngine
 
 plugins {
     alias(libs.plugins.kotlinJvm)
@@ -33,7 +33,7 @@ sourceSets {
     }
 }
 
-tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
+tasks.named<GenerateBpmnModelsTask>("generateBpmnModelApi") {
     baseDir = "${projectDir}/../../configuration"
     filePattern = "newsletter.bpmn"
     outputFolderPath = "$projectDir/src/main/kotlin"
@@ -57,5 +57,5 @@ tasks.withType<Test> {
 }
 
 tasks.named("build") {
-    dependsOn("generateBpmnModels")
+    dependsOn("generateBpmnModelApi")
 }

--- a/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
+++ b/examples/idempotency-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
@@ -3,14 +3,14 @@
 
 package io.miragon.example.adapter.process
 
-import io.github.emaarco.bpmn.runtime.BpmnEngine
-import io.github.emaarco.bpmn.runtime.BpmnFlow
-import io.github.emaarco.bpmn.runtime.BpmnRelations
-import io.github.emaarco.bpmn.runtime.BpmnTimer
-import io.github.emaarco.bpmn.runtime.ElementId
-import io.github.emaarco.bpmn.runtime.MessageName
-import io.github.emaarco.bpmn.runtime.ProcessId
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.BpmnEngine
+import io.miragon.bpmn.runtime.BpmnFlow
+import io.miragon.bpmn.runtime.BpmnRelations
+import io.miragon.bpmn.runtime.BpmnTimer
+import io.miragon.bpmn.runtime.ElementId
+import io.miragon.bpmn.runtime.MessageName
+import io.miragon.bpmn.runtime.ProcessId
+import io.miragon.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 

--- a/examples/outbox-pattern/build.gradle.kts
+++ b/examples/outbox-pattern/build.gradle.kts
@@ -1,6 +1,6 @@
-import io.github.emaarco.bpmn.adapter.GenerateBpmnModelsTask
-import io.github.emaarco.bpmn.domain.shared.OutputLanguage
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.adapter.GenerateBpmnModelsTask
+import io.miragon.bpmn.domain.shared.OutputLanguage
+import io.miragon.bpmn.domain.shared.ProcessEngine
 
 plugins {
     alias(libs.plugins.kotlinJvm)
@@ -33,7 +33,7 @@ sourceSets {
     }
 }
 
-tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
+tasks.named<GenerateBpmnModelsTask>("generateBpmnModelApi") {
     baseDir = "${projectDir}/../../configuration"
     filePattern = "newsletter.bpmn"
     outputFolderPath = "$projectDir/src/main/kotlin"
@@ -57,5 +57,5 @@ tasks.withType<Test> {
 }
 
 tasks.named("build") {
-    dependsOn("generateBpmnModels")
+    dependsOn("generateBpmnModelApi")
 }

--- a/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
+++ b/examples/outbox-pattern/src/main/kotlin/io/miragon/example/adapter/process/NewsletterSubscriptionProcessApi.kt
@@ -3,14 +3,14 @@
 
 package io.miragon.example.adapter.process
 
-import io.github.emaarco.bpmn.runtime.BpmnEngine
-import io.github.emaarco.bpmn.runtime.BpmnFlow
-import io.github.emaarco.bpmn.runtime.BpmnRelations
-import io.github.emaarco.bpmn.runtime.BpmnTimer
-import io.github.emaarco.bpmn.runtime.ElementId
-import io.github.emaarco.bpmn.runtime.MessageName
-import io.github.emaarco.bpmn.runtime.ProcessId
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.BpmnEngine
+import io.miragon.bpmn.runtime.BpmnFlow
+import io.miragon.bpmn.runtime.BpmnRelations
+import io.miragon.bpmn.runtime.BpmnTimer
+import io.miragon.bpmn.runtime.ElementId
+import io.miragon.bpmn.runtime.MessageName
+import io.miragon.bpmn.runtime.ProcessId
+import io.miragon.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 

--- a/examples/saga-pattern/build.gradle.kts
+++ b/examples/saga-pattern/build.gradle.kts
@@ -1,6 +1,6 @@
-import io.github.emaarco.bpmn.adapter.GenerateBpmnModelsTask
-import io.github.emaarco.bpmn.domain.shared.OutputLanguage
-import io.github.emaarco.bpmn.domain.shared.ProcessEngine
+import io.miragon.bpmn.adapter.GenerateBpmnModelsTask
+import io.miragon.bpmn.domain.shared.OutputLanguage
+import io.miragon.bpmn.domain.shared.ProcessEngine
 
 plugins {
     alias(libs.plugins.kotlinJvm)
@@ -33,7 +33,7 @@ sourceSets {
     }
 }
 
-tasks.register<GenerateBpmnModelsTask>("generateBpmnModels") {
+tasks.named<GenerateBpmnModelsTask>("generateBpmnModelApi") {
     baseDir = "${projectDir}/../../configuration"
     filePattern = "payed-newsletter.bpmn"
     outputFolderPath = "$projectDir/src/main/kotlin"
@@ -57,5 +57,5 @@ tasks.withType<Test> {
 }
 
 tasks.named("build") {
-    dependsOn("generateBpmnModels")
+    dependsOn("generateBpmnModelApi")
 }

--- a/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/process/PayedNewsletterSubscriptionProcessApi.kt
+++ b/examples/saga-pattern/src/main/kotlin/io/miragon/example/adapter/process/PayedNewsletterSubscriptionProcessApi.kt
@@ -3,13 +3,13 @@
 
 package io.miragon.example.adapter.process
 
-import io.github.emaarco.bpmn.runtime.BpmnEngine
-import io.github.emaarco.bpmn.runtime.BpmnFlow
-import io.github.emaarco.bpmn.runtime.BpmnRelations
-import io.github.emaarco.bpmn.runtime.ElementId
-import io.github.emaarco.bpmn.runtime.MessageName
-import io.github.emaarco.bpmn.runtime.ProcessId
-import io.github.emaarco.bpmn.runtime.VariableName
+import io.miragon.bpmn.runtime.BpmnEngine
+import io.miragon.bpmn.runtime.BpmnFlow
+import io.miragon.bpmn.runtime.BpmnRelations
+import io.miragon.bpmn.runtime.ElementId
+import io.miragon.bpmn.runtime.MessageName
+import io.miragon.bpmn.runtime.ProcessId
+import io.miragon.bpmn.runtime.VariableName
 import kotlin.String
 import kotlin.Suppress
 
@@ -123,7 +123,7 @@ object PayedNewsletterSubscriptionProcessApi {
           id = "Flow_1gahada",
           sourceRef = "gateway_paymentSuccessful",
           targetRef = "endEvent_paymentFailed",
-          condition = $$"""=paymentSuccessful = false""",
+          condition = "=paymentSuccessful = false",
         )
 
     val FLOW_1_LXG_97_J: BpmnFlow = BpmnFlow(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,4 +47,4 @@ kotlinJpa = { id = "org.jetbrains.kotlin.plugin.jpa", version.ref = "kotlin_vers
 kotlinKapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin_version" }
 springframework = { id = "org.springframework.boot", version.ref = "spring_version" }
 springDependency = { id = "io.spring.dependency-management", version.ref = "spring_dependency_version" }
-bpmnToCode = { id = "io.github.emaarco.bpmn-to-code-gradle", version = "2.1.2" }
+bpmnToCode = { id = "io.miragon.bpmn-to-code-gradle", version = "3.0.0" }


### PR DESCRIPTION
## Summary

Migrates the `bpmn-to-code` Gradle plugin from `io.github.emaarco` 2.1.2 to its new home under `io.miragon` 3.0.0.

## What changed
- **Plugin coordinate**: `io.github.emaarco.bpmn-to-code-gradle:2.1.2` → `io.miragon.bpmn-to-code-gradle:3.0.0`
- **Namespace**: imports and generated runtime types moved from `io.github.emaarco.bpmn.*` to `io.miragon.bpmn.*`
- **Task model**: the plugin now pre-registers its tasks, so the build configures `generateBpmnModelApi` via `tasks.named` instead of registering `generateBpmnModels`. The runtime dependency is now contributed automatically by the plugin.
- Regenerated the process API models for all examples and updated the docs reference.

## Verification
`./gradlew clean build` succeeds — all modules compile and tests pass.

## Breaking?
No behavior change. The generated API surface is identical; only the package namespace changed.